### PR TITLE
Add missing module-infos

### DIFF
--- a/satviz-consumer/src/main/java/module-info.java
+++ b/satviz-consumer/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module edu.kit.satviz.consumer {
+
+  requires edu.kit.satviz.network;
+  requires edu.kit.satviz.parsers;
+  requires com.google.gson;
+  requires net.sourceforge.argparse4j;
+  requires javafx.base;
+  requires javafx.fxml;
+  requires javafx.controls;
+
+}

--- a/satviz-network/src/main/java/module-info.java
+++ b/satviz-network/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module edu.kit.satviz.network {
 
-  requires edu.kit.satviz.sat;
+  requires transitive edu.kit.satviz.sat;
   requires edu.kit.satviz.serial;
 
   exports edu.kit.satviz.network;

--- a/satviz-network/src/main/java/module-info.java
+++ b/satviz-network/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module edu.kit.satviz.network {
+
+  requires edu.kit.satviz.sat;
+  requires edu.kit.satviz.serial;
+
+  exports edu.kit.satviz.network;
+
+}

--- a/satviz-parsers/src/main/java/module-info.java
+++ b/satviz-parsers/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module edu.kit.satviz.parsers {
+
+  requires edu.kit.satviz.sat;
+
+}

--- a/satviz-parsers/src/main/java/module-info.java
+++ b/satviz-parsers/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module edu.kit.satviz.parsers {
 
-  requires edu.kit.satviz.sat;
+  requires transitive edu.kit.satviz.sat;
 
 }

--- a/satviz-sat/src/main/java/module-info.java
+++ b/satviz-sat/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module edu.kit.satviz.sat {
+  exports edu.kit.satviz.sat;
+}

--- a/satviz-serial/src/main/java/module-info.java
+++ b/satviz-serial/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module edu.kit.satviz.serial {
+
+  exports edu.kit.satviz.serial;
+
+}


### PR DESCRIPTION
Diese PR fügt `module-info.java` Dateien für die Module `sat`, `parsers`, `network`, `serial` und `consumer` hinzu, sodass wir überall das Java-Modulsystem nutzen können. Das ist relevant für die Nutzung von incubating APIs (panama), Kapselung/Zugriffskontrolle und später, um einen minimalen Build zu erstellen. 

Die meisten Dinge, die aktuell bearbeitet werden sollten diese Änderungen nicht sofort übernehmen müssen und können vorerst weiterarbeiten.