### PR TITLE
Farbraumkonvertierung & Kreierung von VideoFrames

### DIFF
--- a/satviz-consumer-native/include/satviz/VideoFrame.hpp
+++ b/satviz-consumer-native/include/satviz/VideoFrame.hpp
@@ -5,17 +5,30 @@ namespace satviz {
 namespace video {
 
 /**
+ * Holds the visual information of a single frame of a video.
  *
+ * Pixel values are represented in the YCbCr color space.
+ * The Y, Cb, and Cr components are stored as separate color planes (separate arrays).
  */
 struct VideoFrame {
-  int width;
-  int height;
-  int stride;
+  const int width;
+  const int height;
+  const int stride;
   unsigned char *Y;
   unsigned char *Cb;
   unsigned char *Cr;
 
   VideoFrame(int width, int height);
+  ~VideoFrame();
+
+  /**
+   * Create a VideoFrame from an 8-bit-per-channel RGBA image.
+   * @param width  the width of the image
+   * @param height the height of the image
+   * @param pixels the pixels values of the image
+   * @return       a new VideoFrame
+   */
+  static VideoFrame fromImage(int width, int height, unsigned char *pixels);
 };
 
 } // namespace video

--- a/satviz-consumer-native/include/satviz/VideoFrame.hpp
+++ b/satviz-consumer-native/include/satviz/VideoFrame.hpp
@@ -25,10 +25,10 @@ struct VideoFrame {
    * Create a VideoFrame from an 8-bit-per-channel RGBA image.
    * @param width  the width of the image
    * @param height the height of the image
-   * @param pixels the pixels values of the image
+   * @param data   the pixels values of the image
    * @return       a new VideoFrame
    */
-  static VideoFrame fromImage(int width, int height, unsigned char *pixels);
+  static VideoFrame fromImage(int width, int height, const void *pixels);
 };
 
 } // namespace video

--- a/satviz-consumer-native/include/satviz/YCbCr.hpp
+++ b/satviz-consumer-native/include/satviz/YCbCr.hpp
@@ -1,0 +1,33 @@
+#ifndef SATVIZ_Y_CB_CR_HPP_
+#define SATVIZ_Y_CB_CR_HPP_
+
+namespace satviz {
+namespace video {
+
+/*
+ * Source of conversion formulas:
+ * https://sistenix.com/rgb2ycbcr.html
+ */
+
+inline int rgbToY(int R, int G, int B) {
+  int Y;
+  Y = 16 + (((R<<6) + (R<<1) + (G<<7) + G + (B<<4) + (B<<3) + B) >> 8);
+  return Y;
+}
+
+inline int rgbToCb(int R, int G, int B) {
+  int Cb;
+  Cb = 128 + ((-((R<<5) + (R<<2) + (R<<1)) - ((G<<6) + (G<<3) + (G<<1)) + (B<<7) - (B<<4)) >> 8);
+  return Cb;
+}
+
+inline int rgbToCr(int R, int G, int B) {
+  int Cr;
+  Cr = 128 + (((R<<7) - (R<<4) - ((G<<6) + (G<<5) - (G<<1)) - ((B << 4) + (B << 1))) >> 8);
+  return Cr;
+}
+
+} // namespace video
+} // namespace satviz
+
+#endif //SATVIZ_Y_CB_CR_HPP_

--- a/satviz-consumer-native/include/satviz/YCbCr.hpp
+++ b/satviz-consumer-native/include/satviz/YCbCr.hpp
@@ -11,19 +11,31 @@ namespace video {
 
 inline int rgbToY(int R, int G, int B) {
   int Y;
-  Y = 16 + (((R<<6) + (R<<1) + (G<<7) + G + (B<<4) + (B<<3) + B) >> 8);
+  Y   = (R<<6) + (R<<1);
+  Y  += (G<<7) + G;
+  Y  += (B<<4) + (B<<3) + B;
+  Y >>= 8;
+  Y  += 16;
   return Y;
 }
 
 inline int rgbToCb(int R, int G, int B) {
-  int Cb;
-  Cb = 128 + ((-((R<<5) + (R<<2) + (R<<1)) - ((G<<6) + (G<<3) + (G<<1)) + (B<<7) - (B<<4)) >> 8);
+  int Cb = 0;
+  Cb  -= (R<<5) + (R<<2) + (R<<1);
+  Cb  -= (G<<6) + (G<<3) + (G<<1);
+  Cb  += (B<<7) - (B<<4);
+  Cb >>= 8;
+  Cb  += 128;
   return Cb;
 }
 
 inline int rgbToCr(int R, int G, int B) {
   int Cr;
-  Cr = 128 + (((R<<7) - (R<<4) - ((G<<6) + (G<<5) - (G<<1)) - ((B << 4) + (B << 1))) >> 8);
+  Cr   = (R<<7) - (R<<4);
+  Cr  -= (G<<6) + (G<<5) - (G<<1);
+  Cr  -= (B<<4) + (B<<1);
+  Cr >>= 8;
+  Cr  += 128;
   return Cr;
 }
 

--- a/satviz-consumer-native/src/satviz/CMakeLists.txt
+++ b/satviz-consumer-native/src/satviz/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SRC_SATVIZ_FILES
   GlUtils.cpp
   Camera.cpp
   VideoController.cpp
-)
+  VideoFrame.cpp)
 
 add_library(
   satviz-consumer-native SHARED

--- a/satviz-consumer-native/src/satviz/VideoFrame.cpp
+++ b/satviz-consumer-native/src/satviz/VideoFrame.cpp
@@ -2,6 +2,7 @@
 #include <satviz/YCbCr.hpp>
 
 #include <cstddef>
+#include <cstdint>
 
 namespace satviz {
 namespace video {
@@ -21,16 +22,24 @@ VideoFrame::~VideoFrame() {
 
 VideoFrame VideoFrame::fromImage(int width, int height, const void *data) {
   VideoFrame frame(width, height);
-  const unsigned char *pixels = (const unsigned char *) data;
+  const uint32_t *pixels = (const uint32_t *) data;
   size_t num_pixels = (size_t) width * (size_t) height;
+  unsigned prev = ~pixels[0];
   for (size_t i = 0; i < num_pixels; i++) {
-    // TODO optimize for repeating pixel values
-    int R = pixels[4*i+0];
-    int G = pixels[4*i+1];
-    int B = pixels[4*i+2];
-    frame.Y [i] = (unsigned char) rgbToY (R, G, B);
-    frame.Cb[i] = (unsigned char) rgbToCb(R, G, B);
-    frame.Cr[i] = (unsigned char) rgbToCr(R, G, B);
+    unsigned pixel = pixels[i];
+    if (pixel == prev) {
+      // Optimization: encoding runs of the same color without having to constantly re-convert
+      frame.Y [i] = frame.Y [i-1];
+      frame.Cb[i] = frame.Cb[i-1];
+      frame.Cr[i] = frame.Cr[i-1];
+    } else {
+      unsigned R = (pixel >>  0) & 0xFF;
+      unsigned G = (pixel >>  8) & 0xFF;
+      unsigned B = (pixel >> 16) & 0xFF;
+      frame.Y [i] = (unsigned char) rgbToY (R, G, B);
+      frame.Cb[i] = (unsigned char) rgbToCb(R, G, B);
+      frame.Cr[i] = (unsigned char) rgbToCr(R, G, B);
+    }
   }
   return frame;
 }

--- a/satviz-consumer-native/src/satviz/VideoFrame.cpp
+++ b/satviz-consumer-native/src/satviz/VideoFrame.cpp
@@ -1,0 +1,38 @@
+#include <satviz/VideoFrame.hpp>
+#include <satviz/YCbCr.hpp>
+
+#include <cstddef>
+
+namespace satviz {
+namespace video {
+
+VideoFrame::VideoFrame(int width, int height)
+  : width(width), height(height), stride(width) {
+  Y  = new unsigned char[(size_t) width * (size_t) height];
+  Cb = new unsigned char[(size_t) width * (size_t) height];
+  Cr = new unsigned char[(size_t) width * (size_t) height];
+}
+
+VideoFrame::~VideoFrame() {
+  delete[] Y;
+  delete[] Cb;
+  delete[] Cr;
+}
+
+VideoFrame VideoFrame::fromImage(int width, int height, unsigned char *pixels) {
+  VideoFrame frame(width, height);
+  size_t num_pixels = (size_t) width * (size_t) height;
+  for (size_t i = 0; i < num_pixels; i++) {
+    // TODO optimize for repeating pixel values
+    int R = pixels[4*i+0];
+    int G = pixels[4*i+1];
+    int B = pixels[4*i+2];
+    frame.Y [i] = (unsigned char) rgbToY (R, G, B);
+    frame.Cb[i] = (unsigned char) rgbToCr(R, G, B);
+    frame.Cr[i] = (unsigned char) rgbToCb(R, G, B);
+  }
+  return frame;
+}
+
+} // namespace video
+} // namespace satviz

--- a/satviz-consumer-native/src/satviz/VideoFrame.cpp
+++ b/satviz-consumer-native/src/satviz/VideoFrame.cpp
@@ -19,8 +19,9 @@ VideoFrame::~VideoFrame() {
   delete[] Cr;
 }
 
-VideoFrame VideoFrame::fromImage(int width, int height, unsigned char *pixels) {
+VideoFrame VideoFrame::fromImage(int width, int height, const void *data) {
   VideoFrame frame(width, height);
+  const unsigned char *pixels = (const unsigned char *) data;
   size_t num_pixels = (size_t) width * (size_t) height;
   for (size_t i = 0; i < num_pixels; i++) {
     // TODO optimize for repeating pixel values
@@ -28,8 +29,8 @@ VideoFrame VideoFrame::fromImage(int width, int height, unsigned char *pixels) {
     int G = pixels[4*i+1];
     int B = pixels[4*i+2];
     frame.Y [i] = (unsigned char) rgbToY (R, G, B);
-    frame.Cb[i] = (unsigned char) rgbToCr(R, G, B);
-    frame.Cr[i] = (unsigned char) rgbToCb(R, G, B);
+    frame.Cb[i] = (unsigned char) rgbToCb(R, G, B);
+    frame.Cr[i] = (unsigned char) rgbToCr(R, G, B);
   }
   return frame;
 }

--- a/satviz-consumer-native/test/CMakeLists.txt
+++ b/satviz-consumer-native/test/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GoogleTest)
 add_executable(
   native-test
   Test.cpp
-  YCbCr.cpp)
+  YCbCr.cpp VideoFrame.cpp)
 
 target_link_libraries(
   native-test

--- a/satviz-consumer-native/test/CMakeLists.txt
+++ b/satviz-consumer-native/test/CMakeLists.txt
@@ -8,14 +8,12 @@ include(GoogleTest)
 add_executable(
   native-test
   Test.cpp
-)
+  YCbCr.cpp)
 
 target_link_libraries(
   native-test
   gtest gtest_main
-  OGDF
-  sfml-window
-  ${THEORA_LIBRARIES}
+  satviz-consumer-native
 )
 
 target_include_directories(

--- a/satviz-consumer-native/test/VideoFrame.cpp
+++ b/satviz-consumer-native/test/VideoFrame.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include <satviz/VideoFrame.hpp>
+#include <satviz/YCbCr.hpp>
+#include <cstdio>
+
+using namespace ::satviz::video;
+
+/*
+ * Test whether VideoFrame::fromImage() correctly converts images to video frames.
+ */
+TEST(VideoFrame, FromImage) {
+  const int width  = 1;
+  const int height = 4;
+  // RGBA pixel colors in HTML encoding
+  // We use strings instead of literals integer constants to avoid endianness problems
+  const char *colors[width * height] = {
+      "#FF000000",
+      "#FFFF0000",
+      "#00FFFF00",
+      "#FF0000A0",
+  };
+
+  // convert color codes to pixel values
+  unsigned char pixels[4 * width * height];
+  for (int i = 0; i < width * height; i++) {
+    unsigned r, g, b, a;
+    sscanf(colors[i], "#%2x%2x%2x%2x", &r, &g, &b, &a);
+    pixels[4*i+0] = (unsigned char) r;
+    pixels[4*i+1] = (unsigned char) g;
+    pixels[4*i+2] = (unsigned char) b;
+    pixels[4*i+3] = (unsigned char) a;
+  }
+
+  // Create VideoFrame from image data
+  VideoFrame frame = VideoFrame::fromImage(width, height, pixels);
+  ASSERT_EQ(frame.width,  width);
+  ASSERT_EQ(frame.height, height);
+
+  /* check all pixels */
+  for (int i = 0; i < width * height; i++) {
+    unsigned r, g, b, a;
+    sscanf(colors[i], "#%2x%2x%2x%2x", &r, &g, &b, &a);
+    ASSERT_EQ(frame.Y [i], (unsigned char) rgbToY (r, g, b));
+    ASSERT_EQ(frame.Cb[i], (unsigned char) rgbToCb(r, g, b));
+    ASSERT_EQ(frame.Cr[i], (unsigned char) rgbToCr(r, g, b));
+  }
+}

--- a/satviz-consumer-native/test/VideoFrame.cpp
+++ b/satviz-consumer-native/test/VideoFrame.cpp
@@ -9,12 +9,16 @@ using namespace ::satviz::video;
  * Test whether VideoFrame::fromImage() correctly converts images to video frames.
  */
 TEST(VideoFrame, FromImage) {
-  const int width  = 1;
-  const int height = 4;
+  const int width  = 2;
+  const int height = 3;
   // RGBA pixel colors in HTML encoding
   // We use strings instead of literals integer constants to avoid endianness problems
   const char *colors[width * height] = {
+      // the first three colors help making sure that color runs are interpreted correctly
       "#FF000000",
+      "#FF000000",
+      "#FF000000",
+      // the following colors help making sure that the components are interpreted the right way around
       "#FFFF0000",
       "#00FFFF00",
       "#FF0000A0",

--- a/satviz-consumer-native/test/YCbCr.cpp
+++ b/satviz-consumer-native/test/YCbCr.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <satviz/YCbCr.hpp>
+
+using namespace ::satviz::video;
+
+/*
+ * Compare the output of the RGB to YCbCr conversion functions to known values.
+ */
+TEST(YCbCr, KnownValues) {
+  // black
+  ASSERT_EQ(rgbToY (0, 0, 0),  16);
+  ASSERT_EQ(rgbToCb(0, 0, 0), 128);
+  ASSERT_EQ(rgbToCr(0, 0, 0), 128);
+
+  // white
+  ASSERT_EQ(rgbToY (255, 255, 255), 235);
+  ASSERT_EQ(rgbToCb(255, 255, 255), 128);
+  ASSERT_EQ(rgbToCr(255, 255, 255), 128);
+
+  // yellow
+  ASSERT_EQ(rgbToY (255, 255, 0), 210);
+  ASSERT_EQ(rgbToCb(255, 255, 0),  16);
+  ASSERT_EQ(rgbToCr(255, 255, 0), 145);
+}


### PR DESCRIPTION
Code, um Bilder ("Screenshots") zu VideoFrames zu konvertieren.
Dazu gehört:
1. der Farbraumwechsel von RGB(A) zu YCbCr
2. die Aufteilung des Bildes in einzelne Color Planes. D.h. ein Array pro Farbkomponente

Unit-Tests sind bereits enthalten.