### PR TITLE
Integrate native build toolchain with Gradle

### DIFF
--- a/satviz-consumer/build.gradle.kts
+++ b/satviz-consumer/build.gradle.kts
@@ -15,3 +15,31 @@ dependencies {
 javafx {
     modules("javafx.controls", "javafx.fxml")
 }
+
+val nativeModuleDir = rootProject.file("satviz-consumer-native")
+val nativeBuildDir = nativeModuleDir.resolve("build")
+val sharedLibFile = nativeBuildDir.resolve("src/satviz/libsatviz-consumer-native.so")
+
+tasks {
+    register<Exec>("cmake") {
+        group = "native"
+        outputs.dir(nativeBuildDir)
+        doFirst {
+            nativeBuildDir.mkdir()
+        }
+        workingDir = nativeBuildDir
+        commandLine = listOf("cmake", "..")
+    }
+
+    register<Exec>("make") {
+        group = "native"
+        dependsOn.add("cmake")
+        workingDir = nativeBuildDir
+        commandLine = listOf("make")
+    }
+
+    clean {
+        delete.add(nativeBuildDir)
+    }
+
+}

--- a/satviz-consumer/build.gradle.kts
+++ b/satviz-consumer/build.gradle.kts
@@ -45,6 +45,7 @@ tasks {
 
     clean {
         delete.add(nativeBuildDir)
+        delete.add(nativeModuleDir.resolve("cmake-build-debug"))
     }
 
 }

--- a/satviz-consumer/build.gradle.kts
+++ b/satviz-consumer/build.gradle.kts
@@ -38,6 +38,11 @@ tasks {
         commandLine = listOf("make")
     }
 
+    processResources {
+        dependsOn.add("make")
+        from(sharedLibFile)
+    }
+
     clean {
         delete.add(nativeBuildDir)
     }


### PR DESCRIPTION
Diese PR modifiziert den Gradle build von `satviz-consumer` in folgender Weise:
- Neuer Task namens `cmake`, der CMake für `satviz-consumer-native` ausführt
- Neuer Task namens `make`, der make für `satviz-consumer-native` ausführt (hängt von `cmake` ab)
- Der `clean` Task löscht nun auch die `build` Ordner in `satviz-consumer-native`
- Der `processResources` Task führt nun `make` aus und schiebt die resultierende shared library in die resources von `satviz-consumer`. Damit ist es dann zur Laufzeit verfügbar/gebundlet.

Mit dem Mergen sollten wir noch warten, bis wir den native build ordentlich in die CI integriert haben, sonst schlagen die Unit tests künftig immer fehl.