### PR TITLE
Capturing pixel values from the screen as VideoFrames

### DIFF
--- a/satviz-consumer-native/include/satviz/Display.hpp
+++ b/satviz-consumer-native/include/satviz/Display.hpp
@@ -36,6 +36,11 @@ protected:
    */
   virtual void activateContext() = 0;
 
+  /**
+   * Put the newly drawn frame on the screen.
+   */
+  virtual void displayFrame() = 0;
+
 public:
   virtual ~Display() {}
 
@@ -48,7 +53,7 @@ public:
    * Prepare the OpenGL state to draw a new frame.
    */
   void startFrame();
-  void drawFrame();
+  void endFrame();
   VideoFrame grabFrame();
 
   /**
@@ -58,11 +63,6 @@ public:
    */
   virtual bool pollEvent(sf::Event &event) = 0;
   virtual void lockSize(bool lock) = 0;
-
-  /**
-   * Put the newly drawn frame on the screen.
-   */
-  virtual void displayFrame() = 0;
 };
 
 } // namespace video

--- a/satviz-consumer-native/include/satviz/Display.hpp
+++ b/satviz-consumer-native/include/satviz/Display.hpp
@@ -18,6 +18,7 @@ class Display {
 protected:
   int width;
   int height;
+  unsigned transfer_object; // GL pixel buffer object
 
   Display(int w, int h) : width(w), height(h) {}
 
@@ -42,7 +43,7 @@ protected:
   virtual void displayFrame() = 0;
 
 public:
-  virtual ~Display() {}
+  virtual ~Display();
 
   inline int getWidth() { return width; }
   inline int getHeight() { return height; }
@@ -54,6 +55,7 @@ public:
    */
   void startFrame();
   void endFrame();
+  void transferFrame();
   VideoFrame grabFrame();
 
   /**

--- a/satviz-consumer-native/include/satviz/Display.hpp
+++ b/satviz-consumer-native/include/satviz/Display.hpp
@@ -32,39 +32,46 @@ protected:
    * @return our preferred OpenGL context settings
    */
   static sf::ContextSettings makeContextSettings();
-  /**
-   * Load OpenGL function pointers.
-   *
-   * This is done at object construction time.
-   */
-  void loadGlExtensions();
+  void initializeGl();
+  void deinitializeGl();
+  void onResize();
+
   /**
    * Switch to this Displays OpenGL context.
    */
   virtual void activateContext() = 0;
-
   /**
    * Put the newly drawn frame on the screen.
    */
   virtual void displayFrame() = 0;
 
-  void onResize();
-
 public:
-  virtual ~Display();
+  virtual ~Display() {}
 
   inline int getWidth() { return width; }
   inline int getHeight() { return height; }
-
-  // TODO Camera
 
   /**
    * Prepare the OpenGL state to draw a new frame.
    */
   void startFrame();
+  /**
+   * Stop rendering the current frame and display it on the screen.
+   */
   void endFrame();
-  void transferFrame();
-  VideoFrame grabFrame();
+  /**
+   * Initiate the transfer of the currently drawn frame into RAM.
+   *
+   * The actual transfer will take place asynchronously during the next frame.
+   */
+  void transferCurrentFrame();
+  /**
+   * Convert the previously transferred frame to a VideoFrame.
+   *
+   * (This data is from *two* invocations of transferCurrentFrame() ago!)
+   * @return the VideoFrame
+   */
+  VideoFrame grabPreviousFrame();
 
   /**
    * Poll for user input events.

--- a/satviz-consumer-native/include/satviz/Display.hpp
+++ b/satviz-consumer-native/include/satviz/Display.hpp
@@ -16,9 +16,15 @@ namespace video {
  */
 class Display {
 protected:
+  enum {
+    PBO_IN_PROGRESS,
+    PBO_READY,
+    NUM_PBOS
+  };
+
   int width;
   int height;
-  unsigned transfer_object; // GL pixel buffer object
+  unsigned pbos[NUM_PBOS];
 
   Display(int w, int h) : width(w), height(h) {}
 
@@ -41,6 +47,8 @@ protected:
    * Put the newly drawn frame on the screen.
    */
   virtual void displayFrame() = 0;
+
+  void onResize();
 
 public:
   virtual ~Display();

--- a/satviz-consumer-native/include/satviz/VideoController.hpp
+++ b/satviz-consumer-native/include/satviz/VideoController.hpp
@@ -43,9 +43,24 @@ public:
    */
   void nextFrame();
 
+  /**
+   * Start recording the visualization as a video.
+   * @param filename where the recording should be written to
+   * @param enc the video encoder that should be used
+   * @return false if any errors occur, true otherwise
+   */
   bool startRecording(const char *filename, VideoEncoder *enc);
+  /**
+   * Temporarily stop the recording.
+   */
   void stopRecording();
+  /**
+   * Resume recording if it has been stopped.
+   */
   void resumeRecording();
+  /**
+   * Finish recording altogether and finalize the generated video file.
+   */
   void finishRecording();
 };
 

--- a/satviz-consumer-native/include/satviz/VideoController.hpp
+++ b/satviz-consumer-native/include/satviz/VideoController.hpp
@@ -14,10 +14,21 @@ namespace video {
  */
 class VideoController {
 private:
+  enum RecState {
+    REC_OFF,
+    REC_ON,
+    REC_PAUSED,
+    REC_WINDUP,
+    REC_WINDDOWN,
+  };
+
   graph::Graph &graph;
   Display *display;
   GraphRenderer *renderer;
   Camera camera;
+  enum RecState recording_state;
+
+  void processEvent(sf::Event &event);
 
 public:
   bool wantToClose;

--- a/satviz-consumer-native/include/satviz/VideoFrame.hpp
+++ b/satviz-consumer-native/include/satviz/VideoFrame.hpp
@@ -22,13 +22,13 @@ struct VideoFrame {
   ~VideoFrame();
 
   /**
-   * Create a VideoFrame from an 8-bit-per-channel RGBA image.
+   * Create a VideoFrame from an 8-bit-per-channel BGRA image.
    * @param width  the width of the image
    * @param height the height of the image
    * @param data   the pixels values of the image
    * @return       a new VideoFrame
    */
-  static VideoFrame fromImage(int width, int height, const void *pixels);
+  static VideoFrame fromBgraImage(int width, int height, const void *pixels);
 };
 
 } // namespace video

--- a/satviz-consumer-native/src/satviz/Display.cpp
+++ b/satviz-consumer-native/src/satviz/Display.cpp
@@ -28,5 +28,13 @@ void Display::endFrame() {
   displayFrame();
 }
 
+VideoFrame Display::grabFrame() {
+  unsigned char *pixels = new unsigned char[4 * (size_t) width * (size_t) height];
+  glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+  VideoFrame frame = VideoFrame::fromImage(width, height, pixels);
+  delete[] pixels;
+  return frame;
+}
+
 } // namespace video
 } // namespace satviz

--- a/satviz-consumer-native/src/satviz/Display.cpp
+++ b/satviz-consumer-native/src/satviz/Display.cpp
@@ -36,15 +36,14 @@ void Display::endFrame() {
 
 void Display::transferFrame() {
   glBindBuffer(GL_PIXEL_PACK_BUFFER, transfer_object);
-  // TODO use GL_BGRA encoded images since it's likely a lot faster
-  glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, (void *) 0);
+  glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, (void *) 0);
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 }
 
 VideoFrame Display::grabFrame() {
   glBindBuffer(GL_PIXEL_PACK_BUFFER, transfer_object);
   void *pixels = glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
-  VideoFrame frame = VideoFrame::fromImage(width, height, pixels);
+  VideoFrame frame = VideoFrame::fromBgraImage(width, height, pixels);
   glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
   return frame;

--- a/satviz-consumer-native/src/satviz/Display.cpp
+++ b/satviz-consumer-native/src/satviz/Display.cpp
@@ -5,8 +5,7 @@
 namespace satviz {
 namespace video {
 
-sf::ContextSettings Display::makeContextSettings()
-{
+sf::ContextSettings Display::makeContextSettings() {
   sf::ContextSettings settings;
   settings.attributeFlags |= sf::ContextSettings::Core;
   settings.attributeFlags |= sf::ContextSettings::Debug;
@@ -15,13 +14,11 @@ sf::ContextSettings Display::makeContextSettings()
   return settings;
 }
 
-void Display::loadGlExtensions()
-{
+void Display::loadGlExtensions() {
   gladLoaderLoadGL();
 }
 
-void Display::startFrame()
-{
+void Display::startFrame() {
   glViewport(0, 0, width, height);
   glClearColor(0.3f, 0.3f, 0.3f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);

--- a/satviz-consumer-native/src/satviz/Display.cpp
+++ b/satviz-consumer-native/src/satviz/Display.cpp
@@ -14,10 +14,14 @@ sf::ContextSettings Display::makeContextSettings() {
   return settings;
 }
 
-void Display::loadGlExtensions() {
+void Display::initializeGl() {
   gladLoaderLoadGL();
   glGenBuffers(NUM_PBOS, pbos);
   onResize();
+}
+
+void Display::deinitializeGl() {
+  glDeleteBuffers(NUM_PBOS, pbos);
 }
 
 void Display::onResize() {
@@ -26,10 +30,6 @@ void Display::onResize() {
   glBindBuffer(GL_PIXEL_PACK_BUFFER, pbos[PBO_READY]);
   glBufferData(GL_PIXEL_PACK_BUFFER, 4 * width * height, NULL, GL_STREAM_READ);
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-}
-
-Display::~Display() {
-  glDeleteBuffers(NUM_PBOS, pbos);
 }
 
 void Display::startFrame() {
@@ -48,13 +48,13 @@ void Display::endFrame() {
   displayFrame();
 }
 
-void Display::transferFrame() {
+void Display::transferCurrentFrame() {
   glBindBuffer(GL_PIXEL_PACK_BUFFER, pbos[PBO_IN_PROGRESS]);
   glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, (void *) 0);
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 }
 
-VideoFrame Display::grabFrame() {
+VideoFrame Display::grabPreviousFrame() {
   glBindBuffer(GL_PIXEL_PACK_BUFFER, pbos[PBO_READY]);
   void *pixels = glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
   VideoFrame frame = VideoFrame::fromBgraImage(width, height, pixels);

--- a/satviz-consumer-native/src/satviz/Display.cpp
+++ b/satviz-consumer-native/src/satviz/Display.cpp
@@ -24,5 +24,9 @@ void Display::startFrame() {
   glClear(GL_COLOR_BUFFER_BIT);
 }
 
+void Display::endFrame() {
+  displayFrame();
+}
+
 } // namespace video
 } // namespace satviz

--- a/satviz-consumer-native/src/satviz/OffscreenDisplay.cpp
+++ b/satviz-consumer-native/src/satviz/OffscreenDisplay.cpp
@@ -5,10 +5,11 @@ namespace video {
 
 OffscreenDisplay::OffscreenDisplay(int w, int h)
   : Display(w, h), context(makeContextSettings(), w, h) {
-  loadGlExtensions();
+  initializeGl();
 }
 
 OffscreenDisplay::~OffscreenDisplay() {
+  deinitializeGl();
 }
 
 void OffscreenDisplay::activateContext() {

--- a/satviz-consumer-native/src/satviz/OffscreenDisplay.cpp
+++ b/satviz-consumer-native/src/satviz/OffscreenDisplay.cpp
@@ -4,17 +4,14 @@ namespace satviz {
 namespace video {
 
 OffscreenDisplay::OffscreenDisplay(int w, int h)
-  : Display(w, h), context(makeContextSettings(), w, h)
-{
+  : Display(w, h), context(makeContextSettings(), w, h) {
   loadGlExtensions();
 }
 
-OffscreenDisplay::~OffscreenDisplay()
-{
+OffscreenDisplay::~OffscreenDisplay() {
 }
 
-void OffscreenDisplay::activateContext()
-{
+void OffscreenDisplay::activateContext() {
   context.setActive(true);
 }
 

--- a/satviz-consumer-native/src/satviz/OnscreenDisplay.cpp
+++ b/satviz-consumer-native/src/satviz/OnscreenDisplay.cpp
@@ -4,25 +4,21 @@ namespace satviz {
 namespace video {
 
 OnscreenDisplay::OnscreenDisplay(int w, int h)
-  : Display(w, h)
-{
+  : Display(w, h) {
   sf::ContextSettings settings = makeContextSettings();
   window.create(sf::VideoMode(w, h), "satviz", sf::Style::Default, settings);
   loadGlExtensions();
 }
 
-OnscreenDisplay::~OnscreenDisplay()
-{
+OnscreenDisplay::~OnscreenDisplay() {
   window.close();
 }
 
-void OnscreenDisplay::activateContext()
-{
+void OnscreenDisplay::activateContext() {
   window.setActive(true);
 }
 
-bool OnscreenDisplay::pollEvent(sf::Event &event)
-{
+bool OnscreenDisplay::pollEvent(sf::Event &event) {
   if (window.pollEvent(event)) {
     if (event.type == sf::Event::Resized) {
       width  = event.size.width;
@@ -34,14 +30,12 @@ bool OnscreenDisplay::pollEvent(sf::Event &event)
   }
 }
 
-void OnscreenDisplay::lockSize(bool lock)
-{
+void OnscreenDisplay::lockSize(bool lock) {
   // TODO stub
   (void) lock;
 }
 
-void OnscreenDisplay::displayFrame()
-{
+void OnscreenDisplay::displayFrame() {
   window.display();
 }
 

--- a/satviz-consumer-native/src/satviz/OnscreenDisplay.cpp
+++ b/satviz-consumer-native/src/satviz/OnscreenDisplay.cpp
@@ -23,6 +23,7 @@ bool OnscreenDisplay::pollEvent(sf::Event &event) {
     if (event.type == sf::Event::Resized) {
       width  = event.size.width;
       height = event.size.height;
+      onResize();
     }
     return true;
   } else {

--- a/satviz-consumer-native/src/satviz/OnscreenDisplay.cpp
+++ b/satviz-consumer-native/src/satviz/OnscreenDisplay.cpp
@@ -7,10 +7,11 @@ OnscreenDisplay::OnscreenDisplay(int w, int h)
   : Display(w, h) {
   sf::ContextSettings settings = makeContextSettings();
   window.create(sf::VideoMode(w, h), "satviz", sf::Style::Default, settings);
-  loadGlExtensions();
+  initializeGl();
 }
 
 OnscreenDisplay::~OnscreenDisplay() {
+  deinitializeGl();
   window.close();
 }
 

--- a/satviz-consumer-native/src/satviz/VideoController.cpp
+++ b/satviz-consumer-native/src/satviz/VideoController.cpp
@@ -64,7 +64,7 @@ void VideoController::nextFrame() {
   }
   display->startFrame();
   renderer->draw(camera, display->getWidth(), display->getHeight());
-  display->displayFrame();
+  display->endFrame();
 }
 
 bool VideoController::startRecording(const char *filename, VideoEncoder *enc) {

--- a/satviz-consumer-native/src/satviz/VideoController.cpp
+++ b/satviz-consumer-native/src/satviz/VideoController.cpp
@@ -70,10 +70,10 @@ void VideoController::nextFrame() {
   display->startFrame();
   renderer->draw(camera, display->getWidth(), display->getHeight());
   if (recording_state == REC_ON || recording_state == REC_WINDUP) {
-    display->transferFrame();
+    display->transferCurrentFrame();
   }
   if (recording_state == REC_ON || recording_state == REC_WINDDOWN) {
-    VideoFrame frame = display->grabFrame();
+    VideoFrame frame = display->grabPreviousFrame();
   }
   if (recording_state == REC_WINDUP) {
     recording_state = REC_ON;

--- a/satviz-consumer-native/src/satviz/VideoController.cpp
+++ b/satviz-consumer-native/src/satviz/VideoController.cpp
@@ -1,5 +1,6 @@
 #include <satviz/VideoController.hpp>
 #include <satviz/GlUtils.hpp>
+#include <cassert>
 
 namespace satviz {
 namespace video {
@@ -19,67 +20,91 @@ VideoController::~VideoController() {
   delete display;
 }
 
-void VideoController::nextFrame() {
-  sf::Event event;
-  while (display->pollEvent(event)) {
-    if (event.type == sf::Event::Closed) {
-      wantToClose = true;
+void VideoController::processEvent(sf::Event &event) {
+  if (event.type == sf::Event::Closed) {
+    wantToClose = true;
+  }
+  if (event.type == sf::Event::MouseWheelScrolled) {
+    float factor = 1.0f;
+    if (event.mouseWheelScroll.delta < 0.0f) {
+      factor = 1.0f / 1.5f;
+    } else {
+      factor = 1.0f * 1.5f;
     }
-    if (event.type == sf::Event::MouseWheelScrolled) {
-      float factor = 1.0f;
-      if (event.mouseWheelScroll.delta < 0.0f) {
-        factor = 1.0f / 1.5f;
+    camera.setZoom(camera.getZoom() * factor);
+  }
+  if (event.type == sf::Event::KeyPressed) {
+    if (event.key.code == sf::Keyboard::Left || event.key.code == sf::Keyboard::A) {
+      camera.setX(camera.getX() - 0.2f / camera.getZoom());
+    }
+    if (event.key.code == sf::Keyboard::Right || event.key.code == sf::Keyboard::D) {
+      camera.setX(camera.getX() + 0.2f / camera.getZoom());
+    }
+    if (event.key.code == sf::Keyboard::Down || event.key.code == sf::Keyboard::S) {
+      camera.setY(camera.getY() - 0.2f / camera.getZoom());
+    }
+    if (event.key.code == sf::Keyboard::Up || event.key.code == sf::Keyboard::W) {
+      camera.setY(camera.getY() + 0.2f / camera.getZoom());
+    }
+    if (event.key.code == sf::Keyboard::K) {
+      ogdf::Graph &og = graph.getOgdfGraph();
+      ogdf::node node1 = og.chooseNode();
+      ogdf::node node2 = og.chooseNode();
+      ogdf::edge edge = og.searchEdge(node1, node2, false);
+      if (edge == nullptr) {
+        ogdf::edge edge = og.newEdge(node1, node2);
+        renderer->onEdgeAdded(edge);
       } else {
-        factor = 1.0f * 1.5f;
-      }
-      camera.setZoom(camera.getZoom() * factor);
-    }
-    if (event.type == sf::Event::KeyPressed) {
-      if (event.key.code == sf::Keyboard::Left || event.key.code == sf::Keyboard::A) {
-        camera.setX(camera.getX() - 0.2f / camera.getZoom());
-      }
-      if (event.key.code == sf::Keyboard::Right || event.key.code == sf::Keyboard::D) {
-        camera.setX(camera.getX() + 0.2f / camera.getZoom());
-      }
-      if (event.key.code == sf::Keyboard::Down || event.key.code == sf::Keyboard::S) {
-        camera.setY(camera.getY() - 0.2f / camera.getZoom());
-      }
-      if (event.key.code == sf::Keyboard::Up || event.key.code == sf::Keyboard::W) {
-        camera.setY(camera.getY() + 0.2f / camera.getZoom());
-      }
-      if (event.key.code == sf::Keyboard::K) {
-        ogdf::Graph &og = graph.getOgdfGraph();
-        ogdf::node node1 = og.chooseNode();
-        ogdf::node node2 = og.chooseNode();
-        ogdf::edge edge = og.searchEdge(node1, node2, false);
-        if (edge == nullptr) {
-          ogdf::edge edge = og.newEdge(node1, node2);
-          renderer->onEdgeAdded(edge);
-        } else {
-          renderer->onEdgeDeleted(edge);
-          og.delEdge(edge);
-        }
+        renderer->onEdgeDeleted(edge);
+        og.delEdge(edge);
       }
     }
   }
+}
+
+void VideoController::nextFrame() {
+  sf::Event event;
+  while (display->pollEvent(event)) {
+    processEvent(event);
+  }
   display->startFrame();
   renderer->draw(camera, display->getWidth(), display->getHeight());
+  if (recording_state == REC_ON || recording_state == REC_WINDUP) {
+    display->transferFrame();
+  }
+  if (recording_state == REC_ON || recording_state == REC_WINDDOWN) {
+    VideoFrame frame = display->grabFrame();
+  }
+  if (recording_state == REC_WINDUP) {
+    recording_state = REC_ON;
+  }
+  if (recording_state == REC_WINDDOWN) {
+    recording_state = REC_OFF;
+  }
   display->endFrame();
 }
 
 bool VideoController::startRecording(const char *filename, VideoEncoder *enc) {
   (void) filename;
   (void) enc;
-  return false;
+  assert(recording_state == REC_OFF);
+  recording_state = REC_WINDUP;
+  return true;
 }
 
 void VideoController::stopRecording() {
+  assert(recording_state == REC_ON);
+  recording_state = REC_PAUSED;
 }
 
 void VideoController::resumeRecording() {
+  assert(recording_state == REC_PAUSED);
+  recording_state = REC_ON;
 }
 
 void VideoController::finishRecording() {
+  assert(recording_state == REC_ON);
+  recording_state = REC_WINDDOWN;
 }
 
 } // namespace video

--- a/satviz-consumer-native/src/satviz/VideoFrame.cpp
+++ b/satviz-consumer-native/src/satviz/VideoFrame.cpp
@@ -20,7 +20,7 @@ VideoFrame::~VideoFrame() {
   delete[] Cr;
 }
 
-VideoFrame VideoFrame::fromImage(int width, int height, const void *data) {
+VideoFrame VideoFrame::fromBgraImage(int width, int height, const void *data) {
   VideoFrame frame(width, height);
   const uint32_t *pixels = (const uint32_t *) data;
   size_t num_pixels = (size_t) width * (size_t) height;
@@ -33,9 +33,9 @@ VideoFrame VideoFrame::fromImage(int width, int height, const void *data) {
       frame.Cb[i] = frame.Cb[i-1];
       frame.Cr[i] = frame.Cr[i-1];
     } else {
-      unsigned R = (pixel >>  0) & 0xFF;
+      unsigned B = (pixel >>  0) & 0xFF;
       unsigned G = (pixel >>  8) & 0xFF;
-      unsigned B = (pixel >> 16) & 0xFF;
+      unsigned R = (pixel >> 16) & 0xFF;
       frame.Y [i] = (unsigned char) rgbToY (R, G, B);
       frame.Cb[i] = (unsigned char) rgbToCb(R, G, B);
       frame.Cr[i] = (unsigned char) rgbToCr(R, G, B);

--- a/satviz-consumer-native/test/CMakeLists.txt
+++ b/satviz-consumer-native/test/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GoogleTest)
 add_executable(
   native-test
   Test.cpp
-  YCbCr.cpp VideoFrame.cpp)
+  YCbCr.cpp VideoFrame.cpp Display.cpp)
 
 target_link_libraries(
   native-test

--- a/satviz-consumer-native/test/Display.cpp
+++ b/satviz-consumer-native/test/Display.cpp
@@ -1,0 +1,40 @@
+#include <satviz/OffscreenDisplay.hpp>
+#include <satviz/YCbCr.hpp>
+#include <glad/gl.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::satviz::video;
+
+/*
+ * Test capturing the on-screen frame as a VideoFrame.
+ */
+TEST(Display, FrameCapture) {
+  OffscreenDisplay dpy(16, 16);
+
+  // Draw a completely red frame
+  dpy.startFrame();
+  glClearColor(1.0, 0.0, 0.0, 1.0);
+  glClear(GL_COLOR_BUFFER_BIT);
+  dpy.transferCurrentFrame();
+  dpy.endFrame();
+
+  // Draw a completely green frame
+  dpy.startFrame();
+  glClearColor(0.0, 1.0, 0.0, 1.0);
+  glClear(GL_COLOR_BUFFER_BIT);
+  dpy.transferCurrentFrame();
+  VideoFrame frame1 = dpy.grabPreviousFrame(); // Grab red frame during green frame
+  dpy.endFrame();
+  VideoFrame frame2 = dpy.grabPreviousFrame(); // Grab green frame once it's available
+
+  // Make sure the red frame actually has red pixels
+  ASSERT_EQ(frame1.Y [0], rgbToY (255, 0, 0));
+  ASSERT_EQ(frame1.Cb[0], rgbToCb(255, 0, 0));
+  ASSERT_EQ(frame1.Cr[0], rgbToCr(255, 0, 0));
+
+  // Make sure the green frame actually has green pixels
+  ASSERT_EQ(frame2.Y [0], rgbToY (0, 255, 0));
+  ASSERT_EQ(frame2.Cb[0], rgbToCb(0, 255, 0));
+  ASSERT_EQ(frame2.Cr[0], rgbToCr(0, 255, 0));
+}

--- a/satviz-consumer-native/test/VideoFrame.cpp
+++ b/satviz-consumer-native/test/VideoFrame.cpp
@@ -8,7 +8,7 @@ using namespace ::satviz::video;
 /*
  * Test whether VideoFrame::fromImage() correctly converts images to video frames.
  */
-TEST(VideoFrame, FromImage) {
+TEST(VideoFrame, FromBgraImage) {
   const int width  = 2;
   const int height = 3;
   // RGBA pixel colors in HTML encoding
@@ -29,20 +29,20 @@ TEST(VideoFrame, FromImage) {
   for (int i = 0; i < width * height; i++) {
     unsigned r, g, b, a;
     sscanf(colors[i], "#%2x%2x%2x%2x", &r, &g, &b, &a);
-    pixels[4*i+0] = (unsigned char) r;
+    pixels[4*i+0] = (unsigned char) b;
     pixels[4*i+1] = (unsigned char) g;
-    pixels[4*i+2] = (unsigned char) b;
+    pixels[4*i+2] = (unsigned char) r;
     pixels[4*i+3] = (unsigned char) a;
   }
 
   // Create VideoFrame from image data
-  VideoFrame frame = VideoFrame::fromImage(width, height, pixels);
+  VideoFrame frame = VideoFrame::fromBgraImage(width, height, pixels);
   ASSERT_EQ(frame.width,  width);
   ASSERT_EQ(frame.height, height);
 
   /* check all pixels */
   for (int i = 0; i < width * height; i++) {
-    unsigned r, g, b, a;
+    unsigned b, g, r, a;
     sscanf(colors[i], "#%2x%2x%2x%2x", &r, &g, &b, &a);
     ASSERT_EQ(frame.Y [i], (unsigned char) rgbToY (r, g, b));
     ASSERT_EQ(frame.Cb[i], (unsigned char) rgbToCb(r, g, b));


### PR DESCRIPTION
OpenGL Code, um Pixelwerte effizient vom Bildschirm zurückzulesen.

Der eigentliche Transfer ist pipelined, dh. man muss erst `transferCurrentFrame()` aufrufen damit man in der nächsten Frame die Werte mit `grabPreviousFrame()` auslesen kann.

Die richtige Videoaufnahme-Funktionalität wird (später) durch den `VideoController` gesteuert.
Der Zustand der Aufnahme, also ob sie etwa gerade läuft oder pausiert wird etc.
ist als State-Machine über der Variablen `recording_state` implementiert.