### PR TITLE
ClauseUpdateSerializer

### DIFF
--- a/satviz-sat/src/main/java/edu/kit/satviz/sat/ClauseUpdate.java
+++ b/satviz-sat/src/main/java/edu/kit/satviz/sat/ClauseUpdate.java
@@ -1,5 +1,7 @@
 package edu.kit.satviz.sat;
 
+import java.util.NoSuchElementException;
+
 /**
  * This record adds additional information to the Clause record.<br>
  * One can differentiate between different types of clauses (in the <code>Type</code> enum).
@@ -9,7 +11,37 @@ public record ClauseUpdate(Clause clause, Type type) {
    * This enum holds possible clause update types.
    */
   public enum Type {
-    ADD,
-    REMOVE
+    ADD((byte) 'a'),
+    REMOVE((byte) 'd');
+
+    private final byte id;
+
+    Type(byte id) {
+      this.id = id;
+    }
+
+    /**
+     * Returns the byte-identifier of this {@code Type}.
+     *
+     * @return {@code 'a'} for {@code Type.ADD}, {@code 'd'} for {@code Type.REMOVE}.
+     */
+    public byte getId() {
+      return id;
+    }
+
+    /**
+     * Returns the {@code Type} identified by the given {@code byte}.
+     *
+     * @param id {@code 'a'} for {@code Type.ADD}, {@code 'd'} for {@code Type.REMOVE}.
+     * @return The type, if any
+     * @throws NoSuchElementException if there is no {@code Type} with the given ID
+     */
+    public static Type getById(byte id) {
+      return switch (id) {
+        case 'a' -> ADD;
+        case 'd' -> REMOVE;
+        default -> throw new NoSuchElementException("No Type with id " + id);
+      };
+    }
   }
 }

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
@@ -3,6 +3,9 @@ package edu.kit.satviz.serial;
 import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
 
+/**
+ * The {@link SerialBuilder} corresponding to {@link ClauseUpdateSerializer}.
+ */
 public class ClauseUpdateSerialBuilder extends SerialBuilder<ClauseUpdate> {
 
   // small optimisation because values() has horrible performance characteristics

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
@@ -1,20 +1,34 @@
 package edu.kit.satviz.serial;
 
+import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
 
 public class ClauseUpdateSerialBuilder extends SerialBuilder<ClauseUpdate> {
+
+  // small optimisation because values() has horrible performance characteristics
+  private static final ClauseUpdate.Type[] TYPES = ClauseUpdate.Type.values();
+
+  private final SerialBuilder<Clause> clauseSerialBuilder = new ClauseSerialBuilder();
+
+  private ClauseUpdate.Type type;
+
   @Override
   protected void processAddByte(byte b) throws SerializationException {
-
+    if (type == null) {
+      type = TYPES[b];
+    } else {
+      clauseSerialBuilder.processAddByte(b);
+    }
   }
 
   @Override
   protected ClauseUpdate processGetObject() {
-    return null;
+    return new ClauseUpdate(clauseSerialBuilder.getObject(), type);
   }
 
   @Override
   protected void processReset() {
-
+    type = null;
+    clauseSerialBuilder.reset();
   }
 }

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
@@ -15,6 +15,9 @@ public class ClauseUpdateSerialBuilder extends SerialBuilder<ClauseUpdate> {
   @Override
   protected void processAddByte(byte b) throws SerializationException {
     if (type == null) {
+      if (Byte.compareUnsigned(b, (byte) TYPES.length) >= 0) {
+        fail("Unknown ClausUpdate type ordinal " + b);
+      }
       type = TYPES[b];
     } else {
       clauseSerialBuilder.processAddByte(b);

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
@@ -2,14 +2,12 @@ package edu.kit.satviz.serial;
 
 import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
+import java.util.NoSuchElementException;
 
 /**
  * The {@link SerialBuilder} corresponding to {@link ClauseUpdateSerializer}.
  */
 public class ClauseUpdateSerialBuilder extends SerialBuilder<ClauseUpdate> {
-
-  // small optimisation because values() has horrible performance characteristics
-  private static final ClauseUpdate.Type[] TYPES = ClauseUpdate.Type.values();
 
   private final SerialBuilder<Clause> clauseSerialBuilder = new ClauseSerialBuilder();
 
@@ -18,10 +16,11 @@ public class ClauseUpdateSerialBuilder extends SerialBuilder<ClauseUpdate> {
   @Override
   protected void processAddByte(byte b) throws SerializationException {
     if (type == null) {
-      if (Byte.compareUnsigned(b, (byte) TYPES.length) >= 0) {
-        fail("Unknown ClausUpdate type ordinal " + b);
+      try {
+        type = ClauseUpdate.Type.getById(b);
+      } catch (NoSuchElementException e) {
+        fail("Unknown clause update type " + b);
       }
-      type = TYPES[b];
     } else {
       if (clauseSerialBuilder.addByte(b)) {
         finish();

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerialBuilder.java
@@ -23,7 +23,9 @@ public class ClauseUpdateSerialBuilder extends SerialBuilder<ClauseUpdate> {
       }
       type = TYPES[b];
     } else {
-      clauseSerialBuilder.processAddByte(b);
+      if (clauseSerialBuilder.addByte(b)) {
+        finish();
+      }
     }
   }
 

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerializer.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerializer.java
@@ -16,7 +16,7 @@ public class ClauseUpdateSerializer extends Serializer<ClauseUpdate> {
   @Override
   public void serialize(ClauseUpdate clauseUpdate, OutputStream out)
       throws IOException, SerializationException {
-    out.write(clauseUpdate.type().ordinal());
+    out.write(clauseUpdate.type().getId());
     clauseSerializer.serialize(clauseUpdate.clause(), out);
   }
 

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerializer.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerializer.java
@@ -4,6 +4,11 @@ import edu.kit.satviz.sat.ClauseUpdate;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * A {@link Serializer} for {@code ClauseUpdate}s, i.e. the combination of a {@code Clause} and
+ * a {@code ClauseUpdate.Type}.<br>
+ * Uses one byte for the type and the rest as specified by {@link ClauseSerializer}.
+ */
 public class ClauseUpdateSerializer extends Serializer<ClauseUpdate> {
 
   private static final ClauseSerializer clauseSerializer = new ClauseSerializer();

--- a/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerializer.java
+++ b/satviz-serial/src/main/java/edu/kit/satviz/serial/ClauseUpdateSerializer.java
@@ -5,14 +5,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class ClauseUpdateSerializer extends Serializer<ClauseUpdate> {
+
+  private static final ClauseSerializer clauseSerializer = new ClauseSerializer();
+
   @Override
   public void serialize(ClauseUpdate clauseUpdate, OutputStream out)
       throws IOException, SerializationException {
-
+    out.write(clauseUpdate.type().ordinal());
+    clauseSerializer.serialize(clauseUpdate.clause(), out);
   }
 
   @Override
   public SerialBuilder<ClauseUpdate> getBuilder() {
-    return null;
+    return new ClauseUpdateSerialBuilder();
   }
 }

--- a/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseTest.java
+++ b/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseTest.java
@@ -25,12 +25,12 @@ class ClauseTest {
     assertEquals(6, b.length);
 
     // expect number 2000000000 encoded in 7-bit blocks
-    assertEquals(b[0], (byte) (0x00 | 0x80));
-    assertEquals(b[1], (byte) (0x28 | 0x80));
-    assertEquals(b[2], (byte) (0x56 | 0x80));
-    assertEquals(b[3], (byte) (0x39 | 0x80));
-    assertEquals(b[4], (byte) 0x07);
-    assertEquals(b[5], (byte) 0x00);
+    assertEquals((byte) (0x00 | 0x80), b[0]);
+    assertEquals((byte) (0x28 | 0x80), b[1]);
+    assertEquals((byte) (0x56 | 0x80), b[2]);
+    assertEquals((byte) (0x39 | 0x80), b[3]);
+    assertEquals((byte) 0x07, b[4]);
+    assertEquals((byte) 0x00, b[5]);
 
     ByteArrayInputStream byteIn = new ByteArrayInputStream(b);
     Clause result = null;

--- a/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseUpdateSerializerTest.java
+++ b/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseUpdateSerializerTest.java
@@ -31,7 +31,7 @@ class ClauseUpdateSerializerTest {
     } catch (SerializationException e) {
       fail(e);
     }
-    assertEquals(ClauseUpdate.Type.ADD.ordinal(), out.toByteArray()[0]);
+    assertEquals(ClauseUpdate.Type.ADD.getId(), out.toByteArray()[0]);
   }
 
   @Test

--- a/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseUpdateSerializerTest.java
+++ b/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseUpdateSerializerTest.java
@@ -1,7 +1,6 @@
 package edu.kit.satviz.serial;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
@@ -33,6 +32,12 @@ class ClauseUpdateSerializerTest {
       fail(e);
     }
     assertEquals(ClauseUpdate.Type.ADD.ordinal(), out.toByteArray()[0]);
+  }
+
+  @Test
+  void testUnknownType() {
+    var in = new ByteArrayInputStream(new byte[] {3, 0});
+    assertThrows(SerializationException.class, () -> serializer.deserialize(in));
   }
 
   @Test

--- a/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseUpdateSerializerTest.java
+++ b/satviz-serial/src/test/java/edu/kit/satviz/serial/ClauseUpdateSerializerTest.java
@@ -1,0 +1,54 @@
+package edu.kit.satviz.serial;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import edu.kit.satviz.sat.Clause;
+import edu.kit.satviz.sat.ClauseUpdate;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClauseUpdateSerializerTest {
+
+  private ClauseUpdateSerializer serializer;
+  private ClauseUpdate trivialUpdate;
+  private ClauseUpdate update;
+
+  @BeforeEach
+  void setUp() {
+    serializer = new ClauseUpdateSerializer();
+    trivialUpdate = new ClauseUpdate(new Clause(new int[0]), ClauseUpdate.Type.ADD);
+    update = new ClauseUpdate(new Clause(new int[] {1, 2, -4, 6}), ClauseUpdate.Type.REMOVE);
+  }
+
+  @Test
+  void testSerialize() throws IOException {
+    var out = new ByteArrayOutputStream();
+    try {
+      serializer.serialize(trivialUpdate, out);
+    } catch (SerializationException e) {
+      fail(e);
+    }
+    assertEquals(ClauseUpdate.Type.ADD.ordinal(), out.toByteArray()[0]);
+  }
+
+  @Test
+  void testLoopback() throws IOException {
+    var out = new ByteArrayOutputStream();
+    try {
+      serializer.serialize(update, out);
+    } catch (SerializationException e) {
+      fail(e);
+    }
+    var in = new ByteArrayInputStream(out.toByteArray());
+    try {
+      assertEquals(update, serializer.deserialize(in));
+    } catch (SerializationException e) {
+      fail(e);
+    }
+  }
+
+}

--- a/satviz-serial/src/test/java/edu/kit/satviz/serial/SatAssignmentTest.java
+++ b/satviz-serial/src/test/java/edu/kit/satviz/serial/SatAssignmentTest.java
@@ -43,6 +43,6 @@ class SatAssignmentTest {
     ByteArrayInputStream byteIn = new ByteArrayInputStream(byteOut.toByteArray());
     SatAssignment result = serial.deserialize(byteIn);
 
-    assertEquals(result, assign); // .equals() implemented in SatAssignment
+    assertEquals(assign, result); // .equals() implemented in SatAssignment
   }
 }


### PR DESCRIPTION
Implementiert `ClauseUpdateSerializer` und `ClauseUpdateSerialBuilder`.
Fixt außerdem die Reihenfolge mancher Assertions in existierenden tests (zuerst kommt `expected`, dann `actual`).