### PR TITLE
Native graph data model

### DIFF
--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <tuple>
-#include <sstream>
+#include <iostream>
 
 #include <ogdf/basic/Graph.h>
 #include <ogdf/basic/GraphAttributes.h>
@@ -44,7 +44,8 @@ private:
   std::vector<ogdf::node> node_handles;
   std::vector<GraphObserver*> observers;
 
-  void setup();
+  void initAttrs();
+  void initNodeHandles();
 
 public:
   Graph(size_t num_nodes);
@@ -67,8 +68,8 @@ public:
   void recalculateLayout();
   void adaptLayout();
 
-  std::stringbuf serialize();
-  void deserialize(std::stringbuf &buf);
+  void serialize(std::ostream &stream);
+  void deserialize(std::istream &stream);
 
   NodeInfo queryNode(int index);
   EdgeInfo queryEdge(int index1, int index2);

--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -35,7 +35,7 @@ struct HeatUpdate {
 };
 
 /**
- *
+ * Data storage for the visualization-generated graph.
  */
 class Graph {
 private:
@@ -48,6 +48,10 @@ private:
   void initNodeHandles();
 
 public:
+  /**
+   * The preferred constructor for Graph objects.
+   * @param num_nodes the (fixed) number of nodes that the graph should have
+   */
   Graph(size_t num_nodes);
   /**
    * This variant of the constructor only exists to aid
@@ -56,28 +60,92 @@ public:
   Graph(ogdf::Graph &graphToCopy);
   ~Graph() = default;
 
+  /**
+   * Getter for the number of nodes
+   * @return the number of nodes
+   */
   int numNodes() { return graph.numberOfNodes(); }
+  /**
+   * Getter for the number of edges
+   * @return the number of edges
+   */
   int numEdges() { return graph.numberOfEdges(); }
 
+  /**
+   * Access the underlying OGDF graph
+   * @return a reference to the OGDF graph
+   */
   ogdf::Graph &getOgdfGraph() { return graph; }
+  /**
+   * Access the underlying OGDF graph atttributes
+   * @return a reference to the OGDF graph attributes
+   */
   ogdf::GraphAttributes &getOgdfAttrs() { return attrs; }
 
+  /**
+   * Register an observer
+   * @param o the observer
+   */
   void addObserver(GraphObserver *o);
+  /**
+   * De-register an observer
+   * @param o the observer
+   */
   void removeObserver(GraphObserver *o);
 
+  /**
+   * bulk-update the edge weights in the graph
+   * @param update the weight update
+   */
   void submitWeightUpdate(WeightUpdate &update);
+  /**
+   * bulk-update the node heat values in the graph
+   * @param update the heat update
+   */
   void submitHeatUpdate(HeatUpdate &update);
 
+  /**
+   * Completely recalculate the spacial positioning of the nodes on the screen.
+   */
   void recalculateLayout();
   void adaptLayout();
 
+  /**
+   * Serialize the graph's contents into an output stream.
+   * @param stream the output stream
+   */
   void serialize(std::ostream &stream);
+  /**
+   * Deserialize the graph's contents from an input stream.
+   * @param stream the input stream
+   */
   void deserialize(std::istream &stream);
 
+  /**
+   * Build a bundle of all relevant information pertaining to one specific node in the graph.
+   * @param index the index of the node in the graph
+   * @return a NodeInfo structure
+   */
   NodeInfo queryNode(int index);
+  /**
+   * Build a bundle of all relevant information pertaining to one specific edge in the graph.
+   * @param index1 the index of one end of the edge
+   * @param index1 the index of the other end of the edge
+   * @return an EdgeInfo structure
+   */
   EdgeInfo queryEdge(int index1, int index2);
 
+  /**
+   * Query the x coordinate of a node using an opaque handle.
+   * @param v the node handle
+   * @return the x coordinate value
+   */
   double getX(ogdf::node v) { return attrs.x(v); }
+  /**
+   * Query the y coordinate of a node using an opaque handle.
+   * @param v the node handle
+   * @return the y coordinate value
+   */
   double getY(ogdf::node v) { return attrs.y(v); }
 };
 

--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -42,8 +42,6 @@ private:
   ogdf::Graph graph;
   ogdf::GraphAttributes attrs;
   std::vector<ogdf::node> node_handles;
-  ogdf::NodeArray<unsigned char> node_heat;
-  ogdf::EdgeArray<float> edge_weights;
   std::vector<GraphObserver*> observers;
 
   void setup();
@@ -60,7 +58,8 @@ public:
   ogdf::Graph &getOgdfGraph() { return graph; }
   ogdf::GraphAttributes &getOgdfAttrs() { return attrs; }
 
-  void addObserver(GraphObserver *o) { observers.push_back(o); }
+  void addObserver(GraphObserver *o);
+  void removeObserver(GraphObserver *o);
 
   void submitWeightUpdate(WeightUpdate &update);
   void submitHeatUpdate(HeatUpdate &update);

--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -56,6 +56,9 @@ public:
   Graph(ogdf::Graph &graphToCopy);
   ~Graph() = default;
 
+  int numNodes() { return graph.numberOfNodes(); }
+  int numEdges() { return graph.numberOfEdges(); }
+
   ogdf::Graph &getOgdfGraph() { return graph; }
   ogdf::GraphAttributes &getOgdfAttrs() { return attrs; }
 

--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -41,15 +41,21 @@ class Graph {
 private:
   ogdf::Graph graph;
   ogdf::GraphAttributes attrs;
+  std::vector<ogdf::node> node_handles;
+  ogdf::NodeArray<unsigned char> node_heat;
+  ogdf::EdgeArray<float> edge_weights;
   std::vector<GraphObserver*> observers;
 
+  void setup();
+
 public:
-  Graph(size_t num_nodes = 0);
+  Graph(size_t num_nodes);
   /**
    * This variant of the constructor only exists to aid
    * debugging & testing. It should not be used directly.
    */
   Graph(ogdf::Graph &graphToCopy);
+  ~Graph() = default;
 
   ogdf::Graph &getOgdfGraph() { return graph; }
   ogdf::GraphAttributes &getOgdfAttrs() { return attrs; }

--- a/satviz-consumer-native/src/satviz/CMakeLists.txt
+++ b/satviz-consumer-native/src/satviz/CMakeLists.txt
@@ -31,10 +31,14 @@ target_compile_options(satviz-consumer-native PRIVATE ${SATVIZ_COMPILER_WARNINGS
 
 target_include_directories(
   satviz-consumer-native
-  SYSTEM PUBLIC ${OGDF_INCLUDE_DIRS}
-  SYSTEM PUBLIC ${SFML_INCLUDE_DIRS}
-  SYSTEM PRIVATE ${THEORA_INCLUDE_DIRS}
   PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+target_include_directories(
+  satviz-consumer-native SYSTEM
+  PUBLIC ${CMAKE_SOURCE_DIR}/ogdf/include
+  PUBLIC ${SFML_INCLUDE_DIRS}
+  PRIVATE ${THEORA_INCLUDE_DIRS}
 )
 
 target_link_libraries(

--- a/satviz-consumer-native/src/satviz/Graph.cpp
+++ b/satviz-consumer-native/src/satviz/Graph.cpp
@@ -30,13 +30,19 @@ Graph::Graph(ogdf::Graph &graphToCopy) {
 }
 
 void Graph::submitWeightUpdate(WeightUpdate &update) {
-  // TODO stub
-  (void) update;
+  for (auto row : update.values) {
+    auto v = node_handles[std::get<0>(row)];
+    auto w = node_handles[std::get<1>(row)];
+    auto e = graph.searchEdge(v, w, false);
+    edge_weights[e] = std::get<2>(row);
+  }
 }
 
 void Graph::submitHeatUpdate(HeatUpdate &update) {
-  // TODO stub
-  (void) update;
+  for (auto row : update.values) {
+    auto v = node_handles[std::get<0>(row)];
+    node_heat[v] = std::get<1>(row);
+  }
 }
 
 void Graph::recalculateLayout() {

--- a/satviz-consumer-native/src/satviz/Graph.cpp
+++ b/satviz-consumer-native/src/satviz/Graph.cpp
@@ -17,7 +17,7 @@ void Graph::initAttrs() {
 
 void Graph::initNodeHandles() {
   node_handles.resize(graph.numberOfNodes(), nullptr);
-  for (auto v = graph.firstNode(); v != graph.lastNode(); v = v->succ()) {
+  for (auto v = graph.firstNode(); v != nullptr; v = v->succ()) {
     node_handles[v->index()] = v;
   }
 }

--- a/satviz-consumer-native/test/CMakeLists.txt
+++ b/satviz-consumer-native/test/CMakeLists.txt
@@ -7,7 +7,6 @@ include(GoogleTest)
 
 add_executable(
   native-test
-  Test.cpp
   YCbCr.cpp
   VideoFrame.cpp
   Display.cpp

--- a/satviz-consumer-native/test/CMakeLists.txt
+++ b/satviz-consumer-native/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   YCbCr.cpp
   VideoFrame.cpp
   Display.cpp
+  Graph.cpp
 )
 
 target_compile_options(native-test PRIVATE ${SATVIZ_COMPILER_WARNINGS})

--- a/satviz-consumer-native/test/Graph.cpp
+++ b/satviz-consumer-native/test/Graph.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+
+#include <satviz/Graph.hpp>
+#include <satviz/GraphObserver.hpp>
+
+#include <string>
+#include <sstream>
+
+using namespace ::satviz::graph;
+
+class DummyObserver : public GraphObserver {
+public:
+  std::string log;
+
+  DummyObserver(Graph &gr) : GraphObserver(gr) {}
+
+  virtual void onWeightUpdate(WeightUpdate &update) { (void) update; log.push_back('w'); }
+  virtual void onHeatUpdate(HeatUpdate &update) { (void) update; log.push_back('h'); }
+  virtual void onLayoutChange(ogdf::Array<ogdf::node> &changed) { (void) changed; log.push_back('l'); }
+  virtual void onEdgeAdded(ogdf::edge e) { (void) e; log.push_back('+'); }
+  virtual void onEdgeDeleted(ogdf::edge e) { (void) e; log.push_back('-'); }
+  virtual void onReload() { log.push_back('r'); }
+
+  /**
+   * Check whether a sequence of events happened (in that specific order).
+   * @param seq the sequence of events
+   * @return true if it happened
+   */
+  bool sequenceHappened(const char *seq) {
+    size_t cur = 0;
+    for (size_t i = 0; i < log.length(); i++) {
+      if (log[i] == seq[cur]) {
+        cur++;
+        if (!seq[cur]) return true;
+      }
+    }
+    return false;
+  }
+};
+
+class GraphTest : public ::testing::Test {
+protected:
+  const int     numNodes = 5;
+  Graph         graph;
+  DummyObserver observer;
+
+  WeightUpdate  weightUpdate1;
+  HeatUpdate    heatUpdate1;
+
+  WeightUpdate  weightUpdate2;
+  HeatUpdate    heatUpdate2;
+
+  GraphTest() : graph(numNodes), observer(graph) {
+    graph.addObserver(&observer);
+
+    for (int i = 0; i < numNodes; i++) {
+      // Ring of edges with non-zero, non-uniform weights
+      weightUpdate1.values.push_back(std::make_tuple(i, (i + 1) % numNodes, (float) (i + 1) / (float) numNodes));
+      // Set node heat values to non-zero, non-uniform values
+      heatUpdate1.values.push_back(std::make_tuple(i, i + 1));
+
+      // Set every other edge weight to 0
+      if (i % 2 == 0) {
+        weightUpdate2.values.push_back(std::make_tuple(i, (i + 1) % numNodes, 0.0f));
+      }
+      // Set every other heat value to 0
+      if (i % 2 == 0) {
+        heatUpdate2.values.push_back(std::make_tuple(i, 0));
+      }
+    }
+
+    graph.submitWeightUpdate(weightUpdate1);
+    graph.submitHeatUpdate(heatUpdate1);
+    graph.submitWeightUpdate(weightUpdate2);
+    graph.submitHeatUpdate(heatUpdate2);
+  }
+};
+
+TEST_F(GraphTest, WeightUpdate) {
+  ASSERT_TRUE(observer.sequenceHappened("+++++w---w"));
+  ASSERT_EQ(graph.numEdges(), weightUpdate1.values.size() - weightUpdate2.values.size());
+  for (int i = 0; i < numNodes; i++) {
+    if (i % 2 != 0) {
+      EdgeInfo info = graph.queryEdge(i, (i + 1) % numNodes);
+      ASSERT_EQ(info.weight, (float) (i + 1) / (float) numNodes);
+    }
+  }
+}
+
+TEST_F(GraphTest, HeatUpdate) {
+  ASSERT_TRUE(observer.sequenceHappened("hh"));
+  for (int i = 0; i < numNodes; i++) {
+    NodeInfo info = graph.queryNode(i);
+    if (i % 2 == 0) {
+      ASSERT_EQ(info.heat, 0);
+    } else {
+      ASSERT_EQ(info.heat, i + 1);
+    }
+  }
+}
+
+TEST_F(GraphTest, RecalculateLayout) {
+  ASSERT_FALSE(observer.sequenceHappened("l"));
+  graph.recalculateLayout();
+  ASSERT_TRUE(observer.sequenceHappened("l"));
+}
+
+TEST_F(GraphTest, Serialization) {
+  std::stringstream stream;
+
+  graph.serialize(stream);
+  ASSERT_FALSE(observer.sequenceHappened("r"));
+
+  // Change heat values, then reload previous values
+  graph.submitHeatUpdate(heatUpdate1);
+  graph.deserialize(stream);
+  ASSERT_TRUE(observer.sequenceHappened("r"));
+
+  // Make sure the heat value update has been properly undone
+  for (int i = 0; i < numNodes; i++) {
+    if (i % 2 != 0) continue;
+    NodeInfo info = graph.queryNode(i);
+    ASSERT_EQ(info.heat, 0);
+  }
+}

--- a/satviz-consumer-native/test/Test.cpp
+++ b/satviz-consumer-native/test/Test.cpp
@@ -1,8 +1,0 @@
-// This file only exists to test out Google Test / CMake / CTest / Github Actions interoperability.
-#include <gtest/gtest.h>
-
-// Dummy Test just to check if testing system works
-TEST(HelloTest, BasicAssertions) {
-  EXPECT_STRNE("hello", "world");
-  EXPECT_EQ(7 * 6, 42);
-}


### PR DESCRIPTION
Dieses PR implementiert den Großteil der Funktionalität von `satviz::graph::Graph`.

**Beinhaltet:**
- Ansprechen von Observern
- Verarbeitung von Weight/HeatUpdates
- Serialisierung und Deserialisierung
- jAvAdOcS eVeRyWhErE
- Compiler Warnungen in OGDF Headern gefixt

Alles davon ist (mehr oder weniger) geunittestet, einschließlich der Verwendung von Observern.

**Änderung der Schnittstelle:**
`serialize()` nimmt jetzt einen `std::ostream &` als Parameter.
`deserialize()` nimmt genauso einen `std::istream &`.