### PR TITLE
Tying up various loose ends in satviz-consumer-native.

### DIFF
--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -141,6 +141,8 @@ public:
    * @return the y coordinate value
    */
   double getY(ogdf::node v) { return attrs.y(v); }
+
+  ogdf::edge getEdgeHandle(int index1, int index2);
 };
 
 } // namespace graph

--- a/satviz-consumer-native/src/dummy/Main.cpp
+++ b/satviz-consumer-native/src/dummy/Main.cpp
@@ -23,10 +23,16 @@ int main() {
     wu.values.push_back(std::make_tuple(e->source()->index(), e->target()->index(), (float) rand() / (float) RAND_MAX));
   }
 
+  graph::HeatUpdate hu;
+  for (int i = 0; i < graph.numNodes(); i++) {
+    hu.values.push_back(std::make_tuple(i, rand() & 0xFF));
+  }
+
   video::Display *display = new video::OnscreenDisplay(639, 469);
   video::VideoController controller(graph, display);
   graph.recalculateLayout();
   graph.submitWeightUpdate(wu);
+  graph.submitHeatUpdate(hu);
   while (!controller.wantToClose) {
     controller.nextFrame();
   }

--- a/satviz-consumer-native/src/dummy/Main.cpp
+++ b/satviz-consumer-native/src/dummy/Main.cpp
@@ -5,6 +5,8 @@
 #include <ogdf/basic/graph_generators.h>
 #include <ogdf/layered/DfsAcyclicSubgraph.h>
 
+#include <cstdlib>
+
 using namespace ::satviz;
 
 int main() {
@@ -14,9 +16,17 @@ int main() {
   das.callAndReverse(ogdfGraph);
 
   graph::Graph graph(ogdfGraph);
+  ogdf::Graph &og = graph.getOgdfGraph();
+
+  graph::WeightUpdate wu;
+  for (ogdf::edge e = og.firstEdge(); e; e = e->succ()) {
+    wu.values.push_back(std::make_tuple(e->source()->index(), e->target()->index(), (float) rand() / (float) RAND_MAX));
+  }
+
   video::Display *display = new video::OnscreenDisplay(639, 469);
   video::VideoController controller(graph, display);
   graph.recalculateLayout();
+  graph.submitWeightUpdate(wu);
   while (!controller.wantToClose) {
     controller.nextFrame();
   }

--- a/satviz-consumer-native/src/dummy/Main.cpp
+++ b/satviz-consumer-native/src/dummy/Main.cpp
@@ -30,9 +30,9 @@ int main() {
 
   video::Display *display = new video::OnscreenDisplay(639, 469);
   video::VideoController controller(graph, display);
-  graph.recalculateLayout();
   graph.submitWeightUpdate(wu);
   graph.submitHeatUpdate(hu);
+  graph.recalculateLayout();
   while (!controller.wantToClose) {
     controller.nextFrame();
   }

--- a/satviz-consumer-native/src/satviz/EdgeShader.frag
+++ b/satviz-consumer-native/src/satviz/EdgeShader.frag
@@ -5,5 +5,5 @@ in float weight;
 out vec4 frag_color;
 
 void main() {
-    frag_color = vec4(1.0, 1.0, 1.0, 0.5);
+    frag_color = vec4(1.0, 1.0, 1.0, weight);
 }

--- a/satviz-consumer-native/src/satviz/Graph.cpp
+++ b/satviz-consumer-native/src/satviz/Graph.cpp
@@ -145,5 +145,11 @@ EdgeInfo Graph::queryEdge(int index1, int index2) {
   return info;
 }
 
+ogdf::edge Graph::getEdgeHandle(int index1, int index2) {
+  auto v = node_handles[index1];
+  auto w = node_handles[index2];
+  return graph.searchEdge(v, w, false);
+}
+
 } // namespace graph
 } // namespace satviz

--- a/satviz-consumer-native/src/satviz/Graph.cpp
+++ b/satviz-consumer-native/src/satviz/Graph.cpp
@@ -89,12 +89,20 @@ void Graph::submitHeatUpdate(HeatUpdate &update) {
 }
 
 void Graph::recalculateLayout() {
+  ogdf::EdgeArray<double> lengths(graph);
+  for (auto e = graph.firstEdge(); e; e = e->succ()) {
+    double w = attrs.doubleWeight(e);
+    //double l = 1.0 / (w * w);
+    double l = 1.0 / w;
+    lengths[e] = l;
+  }
+
   ogdf::FMMMLayout fmmm;
   fmmm.useHighLevelOptions(true);
   fmmm.unitEdgeLength(10.0);
-  fmmm.newInitialPlacement(true);
-  fmmm.qualityVersusSpeed(ogdf::FMMMOptions::QualityVsSpeed::GorgeousAndEfficient);
-  fmmm.call(attrs);
+  fmmm.newInitialPlacement(false);
+  fmmm.qualityVersusSpeed(ogdf::FMMMOptions::QualityVsSpeed::NiceAndIncredibleSpeed);
+  fmmm.call(attrs, lengths);
 
   ogdf::Array<ogdf::node> nodes;
   graph.allNodes(nodes);

--- a/satviz-consumer-native/src/satviz/GraphRenderer.cpp
+++ b/satviz-consumer-native/src/satviz/GraphRenderer.cpp
@@ -153,12 +153,13 @@ void GraphRenderer::draw(Camera &camera, int width, int height) {
 }
 
 void GraphRenderer::onWeightUpdate(graph::WeightUpdate &update) {
+  ogdf::GraphAttributes &attrs = my_graph.getOgdfAttrs();
   glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_EDGE_WEIGHT]);
   unsigned char *area = (unsigned char *) glMapBuffer(GL_ARRAY_BUFFER, GL_READ_WRITE);
   for (auto row : update.values) {
     auto e = my_graph.getEdgeHandle(std::get<0>(row), std::get<1>(row));
     int idx = edge_mapping[e];
-    area[idx] = (unsigned char) (std::get<2>(row) * 255.0f);
+    area[idx] = (unsigned char) (attrs.doubleWeight(e) * 255.0f);
   }
   glUnmapBuffer(GL_ARRAY_BUFFER);
 }

--- a/satviz-consumer-native/src/satviz/GraphRenderer.cpp
+++ b/satviz-consumer-native/src/satviz/GraphRenderer.cpp
@@ -153,8 +153,14 @@ void GraphRenderer::draw(Camera &camera, int width, int height) {
 }
 
 void GraphRenderer::onWeightUpdate(graph::WeightUpdate &update) {
-  (void) update;
-  // TODO update & use this attribute.
+  glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_EDGE_WEIGHT]);
+  unsigned char *area = (unsigned char *) glMapBuffer(GL_ARRAY_BUFFER, GL_READ_WRITE);
+  for (auto row : update.values) {
+    auto e = my_graph.getEdgeHandle(std::get<0>(row), std::get<1>(row));
+    int idx = edge_mapping[e];
+    area[idx] = (unsigned char) (std::get<2>(row) * 255.0f);
+  }
+  glUnmapBuffer(GL_ARRAY_BUFFER);
 }
 
 void GraphRenderer::onHeatUpdate(graph::HeatUpdate &update) {
@@ -165,7 +171,6 @@ void GraphRenderer::onHeatUpdate(graph::HeatUpdate &update) {
 void GraphRenderer::onLayoutChange(ogdf::Array<ogdf::node> &changed) {
   glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_NODE_OFFSET]);
   float (*area)[2] = (float (*)[2]) glMapBuffer(GL_ARRAY_BUFFER, GL_READ_WRITE);
-  // TODO proper mapping of nodes to indices!
   printf("onLayoutChange():\n");
   for (ogdf::node node : changed) {
     int idx = node->index();
@@ -223,7 +228,6 @@ void GraphRenderer::onEdgeAdded(ogdf::edge e) {
   }
   int offset = index * sizeof(unsigned[2]);
 
-  // TODO proper mapping of nodes to indices!
   std::array<ogdf::node, 2> nodes = e->nodes();
   int data[2] = { nodes[0]->index(), nodes[1]->index() };
 
@@ -252,8 +256,11 @@ void GraphRenderer::onReload() {
   for (auto edge : edges) {
     onEdgeDeleted(edge);
   }
+  //graph::WeightUpdate wu(my_graph.numEdges());
+  //int idx = 0;
   for (auto edge : edges) {
     onEdgeAdded(edge);
+    //wu.values[idx++] = std::make_tuple(edge->source()->index(), edge->target()->index(), );
   }
 }
 

--- a/satviz-consumer-native/src/satviz/GraphRenderer.cpp
+++ b/satviz-consumer-native/src/satviz/GraphRenderer.cpp
@@ -164,8 +164,13 @@ void GraphRenderer::onWeightUpdate(graph::WeightUpdate &update) {
 }
 
 void GraphRenderer::onHeatUpdate(graph::HeatUpdate &update) {
-  (void) update;
-  // TODO update this attribute.
+  glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_NODE_HEAT]);
+  unsigned char *area = (unsigned char *) glMapBuffer(GL_ARRAY_BUFFER, GL_READ_WRITE);
+  for (auto row : update.values) {
+    int idx = std::get<0>(row);
+    area[idx] = (unsigned char) std::get<1>(row);
+  }
+  glUnmapBuffer(GL_ARRAY_BUFFER);
 }
 
 void GraphRenderer::onLayoutChange(ogdf::Array<ogdf::node> &changed) {

--- a/satviz-consumer-native/src/satviz/VideoController.cpp
+++ b/satviz-consumer-native/src/satviz/VideoController.cpp
@@ -53,14 +53,9 @@ void VideoController::processEvent(sf::Event &event) {
       ogdf::Graph &og = graph.getOgdfGraph();
       ogdf::node node1 = og.chooseNode();
       ogdf::node node2 = og.chooseNode();
-      ogdf::edge edge = og.searchEdge(node1, node2, false);
-      if (edge == nullptr) {
-        ogdf::edge edge = og.newEdge(node1, node2);
-        renderer->onEdgeAdded(edge);
-      } else {
-        renderer->onEdgeDeleted(edge);
-        og.delEdge(edge);
-      }
+      graph::WeightUpdate wu;
+      wu.values.push_back(std::make_tuple(node1->index(), node2->index(), (float) rand() / (float) RAND_MAX));
+      graph.submitWeightUpdate(wu);
     }
     if (event.key.code == sf::Keyboard::R) {
       switch (recording_state) {
@@ -73,6 +68,9 @@ void VideoController::processEvent(sf::Event &event) {
         default:
           break;
       }
+    }
+    if (event.key.code == sf::Keyboard::L) {
+      graph.recalculateLayout();
     }
   }
 }

--- a/satviz-consumer-native/src/satviz/VideoController.cpp
+++ b/satviz-consumer-native/src/satviz/VideoController.cpp
@@ -53,8 +53,14 @@ void VideoController::processEvent(sf::Event &event) {
       ogdf::Graph &og = graph.getOgdfGraph();
       ogdf::node node1 = og.chooseNode();
       ogdf::node node2 = og.chooseNode();
+      ogdf::edge edge = og.searchEdge(node1, node2, false);
+      double old_weight = 0.0;
+      if (edge) {
+        old_weight = graph.getOgdfAttrs().doubleWeight(edge);
+      }
+      double new_weight = (double) rand() / (double) RAND_MAX;
       graph::WeightUpdate wu;
-      wu.values.push_back(std::make_tuple(node1->index(), node2->index(), (float) rand() / (float) RAND_MAX));
+      wu.values.push_back(std::make_tuple(node1->index(), node2->index(), new_weight - old_weight));
       graph.submitWeightUpdate(wu);
     }
     if (event.key.code == sf::Keyboard::R) {

--- a/satviz-consumer-native/test/Graph.cpp
+++ b/satviz-consumer-native/test/Graph.cpp
@@ -61,7 +61,7 @@ protected:
 
       // Set every other edge weight to 0
       if (i % 2 == 0) {
-        weightUpdate2.values.push_back(std::make_tuple(i, (i + 1) % numNodes, 0.0f));
+        weightUpdate2.values.push_back(std::make_tuple(i, (i + 1) % numNodes, -((float) (i + 1) / (float) numNodes)));
       }
       // Set every other heat value to 0
       if (i % 2 == 0) {
@@ -77,24 +77,24 @@ protected:
 };
 
 TEST_F(GraphTest, WeightUpdate) {
-  ASSERT_TRUE(observer.sequenceHappened("+++++w---w"));
-  ASSERT_EQ(graph.numEdges(), weightUpdate1.values.size() - weightUpdate2.values.size());
+  EXPECT_TRUE(observer.sequenceHappened("+++++w---w"));
+  EXPECT_EQ(graph.numEdges(), weightUpdate1.values.size() - weightUpdate2.values.size());
   for (int i = 0; i < numNodes; i++) {
     if (i % 2 != 0) {
       EdgeInfo info = graph.queryEdge(i, (i + 1) % numNodes);
-      ASSERT_EQ(info.weight, (float) (i + 1) / (float) numNodes);
+      EXPECT_EQ(info.weight, (float) (i + 1) / (float) numNodes);
     }
   }
 }
 
 TEST_F(GraphTest, HeatUpdate) {
-  ASSERT_TRUE(observer.sequenceHappened("hh"));
+  EXPECT_TRUE(observer.sequenceHappened("hh"));
   for (int i = 0; i < numNodes; i++) {
     NodeInfo info = graph.queryNode(i);
     if (i % 2 == 0) {
-      ASSERT_EQ(info.heat, 0);
+      EXPECT_EQ(info.heat, 0);
     } else {
-      ASSERT_EQ(info.heat, i + 1);
+      EXPECT_EQ(info.heat, i + 1);
     }
   }
 }


### PR DESCRIPTION
Eine ganze Reihe kleiner, wichtiger Features, die unbedingt vor dem Ende der Implementierungsphase drinnen sein sollten.

- Kantengewichte werden jetzt endlich im Layout einbezogen (!!)
- Kantengewichte & Knotentemperaturen werden jetzt grafisch angezeigt
- WeightUpdates sind jetzt additiv, wie ursprünglich im Entwurf festgelegt