### PR TITLE
Binding for nextFrame()

### DIFF
--- a/satviz-consumer-native/include/satviz/Bindings.h
+++ b/satviz-consumer-native/include/satviz/Bindings.h
@@ -49,7 +49,7 @@ RecordingStartResult satviz_start_recording(void *controller, const char *filena
 void satviz_stop_recording(void *controller);
 void satviz_resume_recording(void *controller);
 void satviz_finish_recording(void *controller);
-void next_frame(void *controller);
+void satviz_next_frame(void *controller);
 void satviz_release_encoder(void *encoder);
 
 #ifdef __cplusplus

--- a/satviz-consumer-native/include/satviz/Bindings.h
+++ b/satviz-consumer-native/include/satviz/Bindings.h
@@ -49,7 +49,7 @@ RecordingStartResult satviz_start_recording(void *controller, const char *filena
 void satviz_stop_recording(void *controller);
 void satviz_resume_recording(void *controller);
 void satviz_finish_recording(void *controller);
-
+void next_frame(void *controller);
 
 #ifdef __cplusplus
 }

--- a/satviz-consumer-native/include/satviz/Bindings.h
+++ b/satviz-consumer-native/include/satviz/Bindings.h
@@ -50,6 +50,7 @@ void satviz_stop_recording(void *controller);
 void satviz_resume_recording(void *controller);
 void satviz_finish_recording(void *controller);
 void next_frame(void *controller);
+void satviz_release_encoder(void *encoder);
 
 #ifdef __cplusplus
 }

--- a/satviz-consumer-native/src/satviz/Bindings.cpp
+++ b/satviz-consumer-native/src/satviz/Bindings.cpp
@@ -125,4 +125,8 @@ void satviz_next_frame(void *controller) {
   reinterpret_cast<VideoController*>(controller)->nextFrame();
 }
 
+void satviz_release_encoder(void *encoder) {
+  delete (VideoEncoder*) encoder;
+}
+
 }

--- a/satviz-consumer-native/src/satviz/Bindings.cpp
+++ b/satviz-consumer-native/src/satviz/Bindings.cpp
@@ -121,4 +121,8 @@ void satviz_finish_recording(void *controller) {
   reinterpret_cast<VideoController*>(controller)->finishRecording();
 }
 
+void satviz_next_frame(void *controller) {
+  reinterpret_cast<VideoController*>(controller)->nextFrame();
+}
+
 }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/display/VideoController.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/display/VideoController.java
@@ -61,6 +61,12 @@ public class VideoController extends NativeObject {
       FunctionDescriptor.ofVoid(CLinker.C_POINTER)
   );
 
+  private static final MethodHandle NEXT_FRAME = lookupFunction(
+      "next_frame",
+      MethodType.methodType(void.class, MemoryAddress.class),
+      FunctionDescriptor.ofVoid(CLinker.C_POINTER)
+  );
+
   private static final Struct START_RECORDING_RESULT = Struct.builder()
       .field("encoder", long.class, CLinker.C_POINTER)
       .field("code", int.class, CLinker.C_INT)
@@ -159,6 +165,17 @@ public class VideoController extends NativeObject {
       freeEncoder();
     } catch (Throwable e) {
       throw new NativeInvocationException("Error while finishing a recording", e);
+    }
+  }
+
+  /**
+   * Progress to the next frame in the visualisation.
+   */
+  public void nextFrame() {
+    try {
+      NEXT_FRAME.invokeExact(getPointer());
+    } catch (Throwable e) {
+      throw new NativeInvocationException("Error while progressing to next frame", e);
     }
   }
 


### PR DESCRIPTION
Fügt `VideoController#nextFrame()` (Java-Seite) hinzu und ändert das releasen des aktuelles `VideoEncoder*` um die C++ `delete` Direktive zu verwenden.