### PR TITLE
Adjust constructor of update structs to set capacity instead of size

### DIFF
--- a/satviz-consumer-native/include/satviz/Graph.hpp
+++ b/satviz-consumer-native/include/satviz/Graph.hpp
@@ -18,14 +18,18 @@ struct WeightUpdate {
   std::vector<std::tuple<int, int, float> > values;
 
   WeightUpdate() = default;
-  explicit WeightUpdate(size_t n) : values(n) {}
+  explicit WeightUpdate(size_t n) {
+    values.reserve(n);
+  }
 };
 
 struct HeatUpdate {
   std::vector<std::tuple<int, int> > values;
 
   HeatUpdate() = default;
-  explicit HeatUpdate(size_t n) : values(n) {}
+  explicit HeatUpdate(size_t n) {
+    values.reserve(n);
+  }
 };
 
 /**


### PR DESCRIPTION
Es gibt derzeit einen Fehler im Konstruktor von `HeatUpdate` und `WeightUpdate` (auf C++ Seite). Dort wird der Konstruktur von `std::vector` aufgerufen, der eine Zahl als Argument hat. Fälschlicherweise habe ich gedacht, dass dies die initiale Kapazität des Vektors ist, tatsächlich scheint es den Vektor aber mit `n` 0-Elementen zu beschreiben. Das habe ich geändert, statt des Konstruktors wird nun `std::vector::reserve` verwendet.