### PR TITLE
Fixed GraphRenderer::onReload() (needed for rewinding)

### DIFF
--- a/satviz-consumer-native/include/satviz/GraphObserver.hpp
+++ b/satviz-consumer-native/include/satviz/GraphObserver.hpp
@@ -16,8 +16,8 @@ protected:
   GraphObserver(Graph &gr) : my_graph(gr) {}
 
 public:
-  virtual void onWeightUpdate(WeightUpdate &update) { (void) update; }
-  virtual void onHeatUpdate(HeatUpdate &update) { (void) update; }
+  virtual void onWeightChange(ogdf::Array<ogdf::edge> &changed) { (void) changed; }
+  virtual void onHeatChange(ogdf::Array<ogdf::node> &changed) { (void) changed; }
   virtual void onLayoutChange(ogdf::Array<ogdf::node> &changed) { (void) changed; }
   virtual void onEdgeAdded(ogdf::edge e) { (void) e; }
   virtual void onEdgeDeleted(ogdf::edge e) { (void) e; }

--- a/satviz-consumer-native/include/satviz/GraphRenderer.hpp
+++ b/satviz-consumer-native/include/satviz/GraphRenderer.hpp
@@ -95,8 +95,8 @@ public:
   void draw(Camera &camera, int width, int height);
 
   // The following methods are all inherited from GraphObserver
-  void onWeightUpdate(graph::WeightUpdate &update) override;
-  void onHeatUpdate(graph::HeatUpdate &update) override;
+  void onWeightChange(ogdf::Array<ogdf::edge> &changed) override;
+  void onHeatChange(ogdf::Array<ogdf::node> &changed) override;
   void onLayoutChange(ogdf::Array<ogdf::node> &changed) override;
   void onEdgeAdded(ogdf::edge e) override;
   void onEdgeDeleted(ogdf::edge e) override;

--- a/satviz-consumer-native/src/satviz/Graph.cpp
+++ b/satviz-consumer-native/src/satviz/Graph.cpp
@@ -48,6 +48,9 @@ void Graph::removeObserver(GraphObserver *o) {
 }
 
 void Graph::submitWeightUpdate(WeightUpdate &update) {
+  ogdf::Array<ogdf::edge> changed(update.values.size());
+  int chg_idx = 0;
+
   for (auto row : update.values) {
     auto v = node_handles[std::get<0>(row)];
     auto w = node_handles[std::get<1>(row)];
@@ -71,22 +74,30 @@ void Graph::submitWeightUpdate(WeightUpdate &update) {
       }
       graph.delEdge(e);
       continue;
+    } else {
+      changed[chg_idx++] = e;
     }
   }
 
+  changed.resize(chg_idx);
+
   for (auto o : observers) {
-    o->onWeightUpdate(update);
+    o->onWeightChange(changed);
   }
 }
 
 void Graph::submitHeatUpdate(HeatUpdate &update) {
+  ogdf::Array<ogdf::node> changed((int) update.values.size());
+  int chg_idx = 0;
+
   for (auto row : update.values) {
     auto v = node_handles[std::get<0>(row)];
     attrs.weight(v) = std::get<1>(row);
+    changed[chg_idx++] = v;
   }
 
   for (auto o : observers) {
-    o->onHeatUpdate(update);
+    o->onHeatChange(changed);
   }
 }
 

--- a/satviz-consumer-native/src/satviz/GraphRenderer.cpp
+++ b/satviz-consumer-native/src/satviz/GraphRenderer.cpp
@@ -189,7 +189,7 @@ int GraphRenderer::allocateEdgeIndex() {
   // Resize everything if we ran out of free indices
   if (free_edges.empty()) {
     // Resize OpenGL buffers
-    int new_capacity = 2 * edge_capacity;
+    int new_capacity = edge_capacity + edge_capacity / 2;
     resizeGlBuffer(&buffer_objects[BO_EDGE_INDICES], edge_capacity * sizeof(unsigned[2]), new_capacity * sizeof (unsigned[2]));
     resizeGlBuffer(&buffer_objects[BO_EDGE_WEIGHT], edge_capacity * sizeof(char), new_capacity * sizeof (char));
 
@@ -248,24 +248,26 @@ void GraphRenderer::onEdgeDeleted(ogdf::edge e) {
 }
 
 void GraphRenderer::onReload() {
-  // TODO also update the other attributes!
-
   ogdf::Array<ogdf::node> nodes;
   my_graph.getOgdfGraph().allNodes(nodes);
-  onLayoutChange(nodes);
-
   ogdf::Array<ogdf::edge> edges;
   my_graph.getOgdfGraph().allEdges(edges);
-  // TODO properly reset edges!
-  for (auto edge : edges) {
-    onEdgeDeleted(edge);
+
+  free_edges.resize(edge_capacity);
+  glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_EDGE_INDICES]);
+  unsigned data[2] = { SENTINEL_INDEX, SENTINEL_INDEX };
+  for (int i = 0; i < edge_capacity; i++) {
+    free_edges[i] = i;
+    glBufferSubData(GL_ARRAY_BUFFER, i * sizeof (unsigned[2]), sizeof (unsigned[2]), data);
   }
-  //graph::WeightUpdate wu(my_graph.numEdges());
-  //int idx = 0;
-  for (auto edge : edges) {
-    onEdgeAdded(edge);
-    //wu.values[idx++] = std::make_tuple(edge->source()->index(), edge->target()->index(), );
+  edge_mapping.fill(-1);
+  for (auto e : edges) {
+    onEdgeAdded(e);
   }
+
+  onHeatChange(nodes);
+  onLayoutChange(nodes);
+  onWeightChange(edges);
 }
 
 } // namespace video

--- a/satviz-consumer-native/src/satviz/GraphRenderer.cpp
+++ b/satviz-consumer-native/src/satviz/GraphRenderer.cpp
@@ -150,25 +150,24 @@ void GraphRenderer::draw(Camera &camera, int width, int height) {
   glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, node_count);
 }
 
-void GraphRenderer::onWeightUpdate(graph::WeightUpdate &update) {
+void GraphRenderer::onWeightChange(ogdf::Array<ogdf::edge> &changed) {
   ogdf::GraphAttributes &attrs = my_graph.getOgdfAttrs();
   glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_EDGE_WEIGHT]);
   unsigned char *area = (unsigned char *) glMapBuffer(GL_ARRAY_BUFFER, GL_READ_WRITE);
-  for (auto row : update.values) {
-    auto e = my_graph.getEdgeHandle(std::get<0>(row), std::get<1>(row));
-    if (!e) continue;
+  for (auto e : changed) {
     int idx = edge_mapping[e];
     area[idx] = (unsigned char) (attrs.doubleWeight(e) * 255.0f);
   }
   glUnmapBuffer(GL_ARRAY_BUFFER);
 }
 
-void GraphRenderer::onHeatUpdate(graph::HeatUpdate &update) {
+void GraphRenderer::onHeatChange(ogdf::Array<ogdf::node> &changed) {
+  ogdf::GraphAttributes &attrs = my_graph.getOgdfAttrs();
   glBindBuffer(GL_ARRAY_BUFFER, buffer_objects[BO_NODE_HEAT]);
   unsigned char *area = (unsigned char *) glMapBuffer(GL_ARRAY_BUFFER, GL_READ_WRITE);
-  for (auto row : update.values) {
-    int idx = std::get<0>(row);
-    area[idx] = (unsigned char) std::get<1>(row);
+  for (auto v : changed) {
+    int idx = v->index();
+    area[idx] = (unsigned char) attrs.weight(v);
   }
   glUnmapBuffer(GL_ARRAY_BUFFER);
 }

--- a/satviz-consumer-native/test/Graph.cpp
+++ b/satviz-consumer-native/test/Graph.cpp
@@ -12,14 +12,14 @@ class DummyObserver : public GraphObserver {
 public:
   std::string log;
 
-  DummyObserver(Graph &gr) : GraphObserver(gr) {}
+  explicit DummyObserver(Graph &gr) : GraphObserver(gr) {}
 
-  virtual void onWeightUpdate(WeightUpdate &update) { (void) update; log.push_back('w'); }
-  virtual void onHeatUpdate(HeatUpdate &update) { (void) update; log.push_back('h'); }
-  virtual void onLayoutChange(ogdf::Array<ogdf::node> &changed) { (void) changed; log.push_back('l'); }
-  virtual void onEdgeAdded(ogdf::edge e) { (void) e; log.push_back('+'); }
-  virtual void onEdgeDeleted(ogdf::edge e) { (void) e; log.push_back('-'); }
-  virtual void onReload() { log.push_back('r'); }
+  virtual void onWeightUpdate(WeightUpdate &update) override { (void) update; log.push_back('w'); }
+  virtual void onHeatUpdate(HeatUpdate &update) override { (void) update; log.push_back('h'); }
+  virtual void onLayoutChange(ogdf::Array<ogdf::node> &changed) override { (void) changed; log.push_back('l'); }
+  virtual void onEdgeAdded(ogdf::edge e) override { (void) e; log.push_back('+'); }
+  virtual void onEdgeDeleted(ogdf::edge e) override { (void) e; log.push_back('-'); }
+  virtual void onReload() override { log.push_back('r'); }
 
   /**
    * Check whether a sequence of events happened (in that specific order).

--- a/satviz-consumer-native/test/Graph.cpp
+++ b/satviz-consumer-native/test/Graph.cpp
@@ -14,8 +14,8 @@ public:
 
   explicit DummyObserver(Graph &gr) : GraphObserver(gr) {}
 
-  virtual void onWeightUpdate(WeightUpdate &update) override { (void) update; log.push_back('w'); }
-  virtual void onHeatUpdate(HeatUpdate &update) override { (void) update; log.push_back('h'); }
+  virtual void onWeightChange(ogdf::Array<ogdf::edge> &changed) override { (void) changed; log.push_back('w'); }
+  virtual void onHeatChange(ogdf::Array<ogdf::node> &changed) override { (void) changed; log.push_back('h'); }
   virtual void onLayoutChange(ogdf::Array<ogdf::node> &changed) override { (void) changed; log.push_back('l'); }
   virtual void onEdgeAdded(ogdf::edge e) override { (void) e; log.push_back('+'); }
   virtual void onEdgeDeleted(ogdf::edge e) override { (void) e; log.push_back('-'); }


### PR DESCRIPTION
Damit wird auch die Definition von `GraphObserver` leicht (in positiver Hinsicht) verändert.

Versucht am besten gar nicht, die genaue Logik in `Graph::submitWeightUpdate()` und `GraphRenderer::onReload()` zu verstehen. Sie ist sehr wirr.