### PR TITLE
Add frequency and recency specialisations of heatmap

### DIFF
--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/ConsumerApplication.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/ConsumerApplication.java
@@ -22,6 +22,7 @@ import edu.kit.satviz.consumer.processing.Heatmap;
 import edu.kit.satviz.consumer.processing.Mediator;
 import edu.kit.satviz.consumer.processing.RecencyHeatmap;
 import edu.kit.satviz.consumer.processing.RingInteractionGraph;
+import edu.kit.satviz.consumer.processing.VariableInteractionGraph;
 import edu.kit.satviz.network.ConsumerConnection;
 import edu.kit.satviz.network.OfferType;
 import edu.kit.satviz.network.ProducerId;

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/ConsumerApplication.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/ConsumerApplication.java
@@ -17,8 +17,10 @@ import edu.kit.satviz.consumer.gui.config.ConfigStarter;
 import edu.kit.satviz.consumer.gui.visualization.VisualizationController;
 import edu.kit.satviz.consumer.gui.visualization.VisualizationStarter;
 import edu.kit.satviz.consumer.processing.ClauseCoordinator;
+import edu.kit.satviz.consumer.processing.FrequencyHeatmap;
 import edu.kit.satviz.consumer.processing.Heatmap;
 import edu.kit.satviz.consumer.processing.Mediator;
+import edu.kit.satviz.consumer.processing.RecencyHeatmap;
 import edu.kit.satviz.consumer.processing.VariableInteractionGraph;
 import edu.kit.satviz.network.ConsumerConnection;
 import edu.kit.satviz.network.OfferType;
@@ -150,7 +152,7 @@ public final class ConsumerApplication {
         .setController(components.controller)
         .setGraph(components.graph)
         .setCoordinator(coordinator)
-        .setHeatmap(new Heatmap(variableAmount))
+        .setHeatmap(new RecencyHeatmap(config.getWindowSize()))
         .setVig(vig)
         .createMediator();
 

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseCoordinator.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseCoordinator.java
@@ -298,7 +298,7 @@ public class ClauseCoordinator implements AutoCloseable {
     changeListener = Objects.requireNonNull(action);
   }
 
-  private long loadClosestSnapshot(long index) throws IOException {
+  private long loadClosestSnapshot(long index) throws IOException, SerializationException {
     // snapshots need to be locked - we don't want to create a snapshot while in the middle of
     // restoring some previous state.
     snapshotLock.lock();

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseUpdateProcessor.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseUpdateProcessor.java
@@ -3,6 +3,8 @@ package edu.kit.satviz.consumer.processing;
 import edu.kit.satviz.consumer.graph.Graph;
 import edu.kit.satviz.consumer.graph.GraphUpdate;
 import edu.kit.satviz.sat.ClauseUpdate;
+import edu.kit.satviz.serial.SerializationException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -27,7 +29,7 @@ public interface ClauseUpdateProcessor {
    *
    * @param out The {@code OutputStream} this processor's state is serialized to.
    */
-  default void serialize(OutputStream out) {
+  default void serialize(OutputStream out) throws IOException {
 
   }
 
@@ -36,7 +38,7 @@ public interface ClauseUpdateProcessor {
    *
    * @param in The {@code InputStream} this processor's state is deserialized from.
    */
-  default void deserialize(InputStream in) {
+  default void deserialize(InputStream in) throws IOException, SerializationException {
 
   }
 

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/FrequencyHeatmap.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/FrequencyHeatmap.java
@@ -1,0 +1,125 @@
+package edu.kit.satviz.consumer.processing;
+
+import edu.kit.satviz.consumer.graph.Graph;
+import edu.kit.satviz.consumer.graph.HeatUpdate;
+import edu.kit.satviz.sat.Clause;
+import edu.kit.satviz.sat.ClauseUpdate;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A specialisation of {@link Heatmap}.
+ * <br>This implementation considers the frequency of each variable in the {@code n} most recently
+ * processed clauses and assigns heat values based on a variable's portion of occurrence.
+ */
+public class FrequencyHeatmap extends Heatmap {
+
+  private final Map<Integer, Integer> frequencies;
+
+  private HeatStrategy strategy;
+
+  /**
+   * Create a frequency-based heatmap with the given initial size.
+   *
+   * @param initialSize The amount of clauses to consider at a time.
+   * @param strategy The strategy to use for heat value calculation.
+   */
+  public FrequencyHeatmap(int initialSize, HeatStrategy strategy) {
+    super(initialSize);
+    this.frequencies = new HashMap<>();
+    this.strategy = strategy;
+  }
+
+  /**
+   * The strategies for determining the heat value given a frequency {@code n}.
+   */
+  public enum HeatStrategy {
+    /**
+     * {@code n / maxFrequencyOfRecentVariables}.
+     */
+    MAX_FREQUENCY,
+
+    /**
+     * {@code n / currentHeatmapPopulationSize}.
+     */
+    SIZE
+  }
+
+  @Override
+  public HeatUpdate process(ClauseUpdate[] updates, Graph graph) {
+    int totalAmount = cursor;
+    boolean full = false;
+    for (ClauseUpdate update : updates) {
+      Clause clause = update.clause();
+      Clause previous = recentClauses[cursor];
+      if (previous != null) {
+        // if we encounter an existing element, the ring buffer is full and
+        // the variables' frequencies need to be decremented
+        full = true;
+        decreaseFrequencies(previous);
+      }
+      recentClauses[cursor] = clause;
+      increaseFrequencies(clause);
+      totalAmount++;
+      increaseCursor();
+    }
+    return populateUpdate(
+        switch (strategy) {
+          case MAX_FREQUENCY -> frequencies.values().stream().reduce(1, Math::max);
+          case SIZE -> full ? recentClauses.length : totalAmount;
+        });
+  }
+
+  public HeatStrategy getStrategy() {
+    return strategy;
+  }
+
+  public void setStrategy(HeatStrategy strategy) {
+    this.strategy = strategy;
+  }
+
+  @Override
+  protected void removeClause(Clause clause) {
+    decreaseFrequencies(clause);
+  }
+
+  /* Calculate the updated heat values for each node based on its frequency and the total amount
+   of nodes currently being updated. */
+  private HeatUpdate populateUpdate(int totalAmount) {
+    HeatUpdate update = new HeatUpdate();
+    var iterator = frequencies.entrySet().iterator();
+    while (iterator.hasNext()) {
+      var entry = iterator.next();
+      // key - 1 here to convert between 1-indexed variables and 0-indexed graph nodes
+      update.add(entry.getKey() - 1, (float) entry.getValue() / totalAmount);
+      if (entry.getValue() == 0) {
+        iterator.remove();
+      }
+    }
+    return update;
+  }
+
+  /* Increment the frequencies of the variables in a clause */
+  private void increaseFrequencies(Clause clause) {
+    for (int literal : clause.literals()) {
+      frequencies.compute(Math.abs(literal), (k, v) -> v == null ? 1 : v + 1);
+    }
+  }
+
+  /* Decrement the frequencies of the variables in a clause - not going lower than 0 */
+  private void decreaseFrequencies(Clause clause) {
+    for (int literal : clause.literals()) {
+      int variable = Math.abs(literal);
+      Integer val = frequencies.get(variable);
+      if (val != null && val > 0) {
+        frequencies.put(variable, val - 1);
+      }
+    }
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    frequencies.clear();
+  }
+}

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/FrequencyHeatmap.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/FrequencyHeatmap.java
@@ -111,7 +111,9 @@ public class FrequencyHeatmap extends Heatmap {
     for (int literal : clause.literals()) {
       int variable = Math.abs(literal);
       Integer val = frequencies.get(variable);
-      if (val != null && val > 0) {
+      if (val == null) {
+        frequencies.put(variable, 0);
+      } else if (val > 0) {
         frequencies.put(variable, val - 1);
       }
     }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RecencyHeatmap.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RecencyHeatmap.java
@@ -5,7 +5,9 @@ import edu.kit.satviz.consumer.graph.HeatUpdate;
 import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A specialisation of {@link Heatmap}.
@@ -14,7 +16,7 @@ import java.util.List;
  */
 public class RecencyHeatmap extends Heatmap {
 
-  private final List<Clause> setToZero;
+  private final Set<Integer> setToZero;
 
   /**
    * Create a recency-based heatmap with the given initial size.
@@ -23,7 +25,7 @@ public class RecencyHeatmap extends Heatmap {
    */
   public RecencyHeatmap(int initialSize) {
     super(initialSize);
-    this.setToZero = new ArrayList<>();
+    this.setToZero = new HashSet<>();
   }
 
   @Override
@@ -54,16 +56,16 @@ public class RecencyHeatmap extends Heatmap {
   }
 
   private void zeroPendingVariables(HeatUpdate update) {
-    for (Clause clause : setToZero) {
-      for (int literal : clause.literals()) {
-        update.add(Math.abs(literal) - 1, 0);
-      }
+    for (int variable : setToZero) {
+      update.add(variable - 1, 0);
     }
     setToZero.clear();
   }
 
   @Override
   protected void removeClause(Clause clause) {
-    setToZero.add(clause);
+    for (int literal : clause.literals()) {
+      setToZero.add(Math.abs(literal));
+    }
   }
 }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RecencyHeatmap.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RecencyHeatmap.java
@@ -1,0 +1,69 @@
+package edu.kit.satviz.consumer.processing;
+
+import edu.kit.satviz.consumer.graph.Graph;
+import edu.kit.satviz.consumer.graph.HeatUpdate;
+import edu.kit.satviz.sat.Clause;
+import edu.kit.satviz.sat.ClauseUpdate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A specialisation of {@link Heatmap}.
+ * <br>This implementation considers the <em>recency</em> of each variable in the {@code n}
+ * most recently processed clauses and assigns heat values based on most recent appearances.
+ */
+public class RecencyHeatmap extends Heatmap {
+
+  private final List<Clause> setToZero;
+
+  /**
+   * Create a recency-based heatmap with the given initial size.
+   *
+   * @param initialSize The amount of clauses to consider at a time.
+   */
+  public RecencyHeatmap(int initialSize) {
+    super(initialSize);
+    this.setToZero = new ArrayList<>();
+  }
+
+  @Override
+  public HeatUpdate process(ClauseUpdate[] updates, Graph graph) {
+
+    for (ClauseUpdate update : updates) {
+      Clause previous = recentClauses[cursor];
+      if (previous != null) {
+        removeClause(previous);
+      }
+      recentClauses[cursor] = update.clause();
+      increaseCursor();
+    }
+
+    int size = recentClauses.length;
+    HeatUpdate update = new HeatUpdate();
+    zeroPendingVariables(update);
+    for (int i = 0; i < size; i++) {
+      Clause subject = recentClauses[(i + cursor) % size];
+      if (subject == null) {
+        continue;
+      }
+      for (int literal : subject.literals()) {
+        update.add(Math.abs(literal) - 1, (float) i / size);
+      }
+    }
+    return update;
+  }
+
+  private void zeroPendingVariables(HeatUpdate update) {
+    for (Clause clause : setToZero) {
+      for (int literal : clause.literals()) {
+        update.add(Math.abs(literal) - 1, 0);
+      }
+    }
+    setToZero.clear();
+  }
+
+  @Override
+  protected void removeClause(Clause clause) {
+    setToZero.add(clause);
+  }
+}

--- a/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/FrequencyHeatmapTest.java
+++ b/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/FrequencyHeatmapTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class HeatmapTest {
+class FrequencyHeatmapTest {
 
   private static final Clause[] CLAUSES = {
       new Clause(new int[] {1, 6, -5, 3}),
@@ -27,7 +27,7 @@ class HeatmapTest {
 
   @BeforeEach
   void setUp() {
-    heatmap = new Heatmap(3);
+    heatmap = new FrequencyHeatmap(3, FrequencyHeatmap.HeatStrategy.SIZE);
   }
 
   @Test


### PR DESCRIPTION
Fügt eine sinnvolle Abstraktion für `Heatmap` ein um beide von uns entwickelten Spezialisierungen gleichzeitig zu haben. Fixt außerdem einen Bug in `ConsumerApplication`, der statt der initialen Heatmap-Größe die Variablenanzahl der Instanz wählt.

Zudem wurde in der recency-Strategie das "Wegfallen" von Klauseln ordentlich implementiert (fehlte zuvor) und in `Heatmap#reset()`/`deserialize()` dafür gesorgt, dass die Heatmap nun tatsächlich richtig zurückgesetzt wird, indem alle aktuellen und ggf. "damaligen" Klauseln aus der Betrachtung entfernt werden.

Damit die serialisation Methoden von `ClauseUpdateProcessor` tatsächlich angenehm benutzt werden können, habe ich an entsprechenden Stellen `throws`-Deklarationen hinzugefügt.