### PR TITLE
Fix GUI video recording

### DIFF
--- a/satviz-consumer-native/include/satviz/Bindings.h
+++ b/satviz-consumer-native/include/satviz/Bindings.h
@@ -50,7 +50,6 @@ void satviz_stop_recording(void *controller);
 void satviz_resume_recording(void *controller);
 void satviz_finish_recording(void *controller);
 void satviz_next_frame(void *controller);
-void satviz_release_encoder(void *encoder);
 
 #ifdef __cplusplus
 }

--- a/satviz-consumer-native/include/satviz/Bindings.h
+++ b/satviz-consumer-native/include/satviz/Bindings.h
@@ -38,14 +38,9 @@ NodeInfo satviz_query_node(void *graph, int index);
 EdgeInfo satviz_query_edge(void *graph, int index1, int index2);
 
 // VideoController
-typedef struct RecordingStartResult {
-  void *encoder;
-  int code;
-} RecordingStartResult;
-
 void *satviz_new_video_controller(void *graph, int display_type, int width, int height);
 void satviz_release_video_controller(void *controller);
-RecordingStartResult satviz_start_recording(void *controller, const char *filename, const char *encoder_name);
+int satviz_start_recording(void *controller, const char *filename, const char *encoder_name);
 void satviz_stop_recording(void *controller);
 void satviz_resume_recording(void *controller);
 void satviz_finish_recording(void *controller);

--- a/satviz-consumer-native/src/satviz/Bindings.cpp
+++ b/satviz-consumer-native/src/satviz/Bindings.cpp
@@ -104,10 +104,7 @@ RecordingStartResult satviz_start_recording(void *controller, const char *filena
         -1
     };
   }
-  return RecordingStartResult {
-      encoder,
-      reinterpret_cast<VideoController*>(controller)->startRecording(filename, encoder)
-  };
+  return reinterpret_cast<VideoController*>(controller)->startRecording(filename, encoder);
 }
 
 void satviz_stop_recording(void *controller) {

--- a/satviz-consumer-native/src/satviz/Bindings.cpp
+++ b/satviz-consumer-native/src/satviz/Bindings.cpp
@@ -93,16 +93,13 @@ void satviz_release_video_controller(void *controller) {
   delete (VideoController*) controller;
 }
 
-RecordingStartResult satviz_start_recording(void *controller, const char *filename, const char *encoder_name) {
+int satviz_start_recording(void *controller, const char *filename, const char *encoder_name) {
   VideoEncoder *encoder;
   std::string enc_name_str { encoder_name };
   if (enc_name_str == "theora") {
     encoder = new TheoraEncoder;
   } else {
-    return RecordingStartResult {
-        nullptr,
-        -1
-    };
+    return -1;
   }
   return reinterpret_cast<VideoController*>(controller)->startRecording(filename, encoder);
 }

--- a/satviz-consumer-native/src/satviz/Bindings.cpp
+++ b/satviz-consumer-native/src/satviz/Bindings.cpp
@@ -126,8 +126,4 @@ void satviz_next_frame(void *controller) {
   reinterpret_cast<VideoController*>(controller)->nextFrame();
 }
 
-void satviz_release_encoder(void *encoder) {
-  delete (VideoEncoder*) encoder;
-}
-
 }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/display/VideoController.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/display/VideoController.java
@@ -20,11 +20,6 @@ import jdk.incubator.foreign.SegmentAllocator;
  */
 public class VideoController extends NativeObject {
 
-  private static final Struct START_RECORDING_RESULT = Struct.builder()
-      .field("encoder", long.class, CLinker.C_POINTER)
-      .field("code", int.class, CLinker.C_INT)
-      .build();
-
   private static final MethodHandle NEW_CONTROLLER = lookupFunction(
       "new_video_controller",
       MethodType.methodType(MemoryAddress.class, MemoryAddress.class,
@@ -41,9 +36,9 @@ public class VideoController extends NativeObject {
 
   private static final MethodHandle START_RECORDING = lookupFunction(
       "start_recording",
-      MethodType.methodType(MemorySegment.class, MemoryAddress.class,
+      MethodType.methodType(int.class, MemoryAddress.class,
           MemoryAddress.class, MemoryAddress.class),
-      FunctionDescriptor.of(START_RECORDING_RESULT.getLayout(), CLinker.C_POINTER,
+      FunctionDescriptor.of(CLinker.C_INT, CLinker.C_POINTER,
           CLinker.C_POINTER, CLinker.C_POINTER)
   );
 
@@ -112,17 +107,16 @@ public class VideoController extends NativeObject {
    */
   public boolean startRecording(String fileName, String encoder) {
     try (ResourceScope local = ResourceScope.newConfinedScope()) {
-      MemorySegment res = (MemorySegment) START_RECORDING.invokeExact(
+      int res = (int) START_RECORDING.invokeExact(
           SegmentAllocator.ofScope(local),
           getPointer(),
           CLinker.toCString(fileName, local).address(),
           CLinker.toCString(encoder, local).address()
       );
-      int resultCode = (int) START_RECORDING_RESULT.varHandle("code").get(res);
-      if (resultCode == -1) {
+      if (res == -1) {
         throw new IllegalArgumentException("Unsupported encoder " + encoder);
       }
-      return resultCode != 0;
+      return res != 0;
     } catch (Throwable e) {
       throw new NativeInvocationException("Error while starting a recording", e);
     }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/display/VideoController.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/display/VideoController.java
@@ -108,7 +108,6 @@ public class VideoController extends NativeObject {
   public boolean startRecording(String fileName, String encoder) {
     try (ResourceScope local = ResourceScope.newConfinedScope()) {
       int res = (int) START_RECORDING.invokeExact(
-          SegmentAllocator.ofScope(local),
           getPointer(),
           CLinker.toCString(fileName, local).address(),
           CLinker.toCString(encoder, local).address()

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/Mediator.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/Mediator.java
@@ -10,6 +10,8 @@ import edu.kit.satviz.sat.ClauseUpdate;
 import edu.kit.satviz.sat.SatAssignment;
 import edu.kit.satviz.serial.SerializationException;
 import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -25,6 +27,7 @@ public class Mediator implements ConsumerConnectionListener {
   private final ConsumerConfig config;
   private final ScheduledExecutorService glScheduler;
   private final long period;
+  private final Queue<Runnable> taskQueue;
 
   private boolean recording;
   private boolean recordingPaused;
@@ -54,6 +57,7 @@ public class Mediator implements ConsumerConnectionListener {
     this.visualizationPaused = true;
     this.clausesPerAdvance = config.getBufferSize();
     this.period = config.getPeriod();
+    this.taskQueue = new LinkedBlockingQueue<>();
     //System.out.println("Period: " + period + ", buffer: " + clausesPerAdvance);
     coordinator.addProcessor(heatmap);
     coordinator.addProcessor(vig);
@@ -64,7 +68,7 @@ public class Mediator implements ConsumerConnectionListener {
   }
 
   public void updateWindowSize(int windowSize) {
-    glScheduler.submit(() -> heatmap.setHeatmapSize(windowSize));
+    taskQueue.offer(() -> heatmap.setHeatmapSize(windowSize));
   }
 
   public void updateHeatmapColdColor(Color color) {
@@ -101,11 +105,14 @@ public class Mediator implements ConsumerConnectionListener {
 
   public void startOrStopRecording() {
     if (recording) {
-      glScheduler.submit(videoController::finishRecording);
+      if (recordingPaused) {
+        taskQueue.offer(videoController::resumeRecording);
+      }
+      taskQueue.offer(videoController::finishRecording);
     } else {
       String filename = config.getVideoTemplatePath()
           .replace("{}", String.valueOf(++recordedVideos));
-      glScheduler.submit(() -> videoController.startRecording(filename, "theora"));
+      taskQueue.offer(() -> videoController.startRecording(filename, "theora"));
     }
     recordingPaused = false;
     recording = !recording;
@@ -114,9 +121,9 @@ public class Mediator implements ConsumerConnectionListener {
   public void pauseOrContinueRecording() {
     if (recording) {
       if (recordingPaused) {
-        glScheduler.submit(videoController::resumeRecording);
+        taskQueue.offer(videoController::resumeRecording);
       } else {
-        glScheduler.submit(videoController::stopRecording);
+        taskQueue.offer(videoController::stopRecording);
       }
       recordingPaused = !recordingPaused;
     }
@@ -137,11 +144,11 @@ public class Mediator implements ConsumerConnectionListener {
   }
 
   public void relayout() {
-    glScheduler.submit(graph::recalculateLayout);
+    taskQueue.offer(graph::recalculateLayout);
   }
 
   public void seekToUpdate(long index) {
-    glScheduler.submit(() -> {
+    taskQueue.offer(() -> {
       try {
         coordinator.seekToUpdate(index);
       } catch (Throwable e) { // TODO: 10/02/2022
@@ -175,6 +182,9 @@ public class Mediator implements ConsumerConnectionListener {
       }
       //System.out.println("Post advance");
       videoController.nextFrame();
+      while (!taskQueue.isEmpty()) {
+        taskQueue.poll().run();
+      }
       //System.out.println("Post nextframe");
     } catch (Throwable e) {
       e.printStackTrace();

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/Mediator.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/Mediator.java
@@ -24,13 +24,13 @@ public class Mediator implements ConsumerConnectionListener {
   private final VariableInteractionGraph vig;
   private final ConsumerConfig config;
   private final ScheduledExecutorService glScheduler;
+  private final long period;
 
   private boolean recording;
   private boolean recordingPaused;
   private volatile boolean visualizationPaused;
   private int recordedVideos;
   private volatile int clausesPerAdvance;
-  private volatile long period;
 
   private Mediator(
       ScheduledExecutorService glScheduler,
@@ -75,10 +75,6 @@ public class Mediator implements ConsumerConnectionListener {
     // TODO: 19/02/2022
   }
 
-  public void setPeriod(long period) {
-    this.period = period;
-  }
-
   public void setClausesPerAdvance(int clausesPerAdvance) {
     this.clausesPerAdvance = clausesPerAdvance;
   }
@@ -109,10 +105,7 @@ public class Mediator implements ConsumerConnectionListener {
     } else {
       String filename = config.getVideoTemplatePath()
           .replace("{}", String.valueOf(++recordedVideos));
-      glScheduler.submit(() -> {
-        videoController.startRecording(filename, "theora");
-        System.out.println("Recording started");
-      });
+      glScheduler.submit(() -> videoController.startRecording(filename, "theora"));
     }
     recordingPaused = false;
     recording = !recording;


### PR DESCRIPTION
Fixt Bugs rund um die Videoaufnahme über das Visualisierungsgui.

- Double free error beim Stoppen der Aufnahme - mir war nicht klar, dass der VideoEncoder bereits im nativen Teil freigegeben wird. Entsprechend redundanter Code wurde entfernt.
- start -> pause -> stop führte zu Fehlern. Das wurde behoben
- Der `Mediator` allgemein schiebt nun OpenGL tasks nicht direkt auf den OpenGL Thread sondern in eine Task-Queue, deren Aufgaben immer genau beim nächsten Frame durchgeführt werden (sonst kann je nach Frame-Aufwand sehr lange dauern, bis Aufgaben ausgeführt werden).