### PR TITLE
Variable->Node-Mapping

### DIFF
--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/ConsumerApplication.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/ConsumerApplication.java
@@ -88,7 +88,7 @@ public final class ConsumerApplication {
       logger.log(Level.INFO, "Instance contains {0} variables", variableAmount);
       ClauseUpdate[] clauses = StreamSupport.stream(dimacsFile.spliterator(), false)
           .toArray(ClauseUpdate[]::new);
-      initialUpdate = vig.process(clauses, null);
+      initialUpdate = vig.process(clauses, null, literal -> Math.abs(literal) - 1);
     } catch (ParsingException e) {
       if (!config.isNoGui()) {
         // Error window.
@@ -133,7 +133,7 @@ public final class ConsumerApplication {
     }).get();
 
     ClauseCoordinator coordinator = new ClauseCoordinator(components.graph,
-        tempDir, variableAmount);
+        tempDir, variableAmount, literal -> Math.abs(literal) - 1);
 
     Mediator mediator = new Mediator.MediatorBuilder()
         .setConfig(config)

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseUpdateProcessor.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseUpdateProcessor.java
@@ -7,6 +7,7 @@ import edu.kit.satviz.serial.SerializationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.IntUnaryOperator;
 
 /**
  * This interface allows for instances of the {@code ClauseUpdate} class to be
@@ -19,9 +20,10 @@ public interface ClauseUpdateProcessor {
    *
    * @param clauseUpdates An array of {@code ClauseUpdate}s.
    * @param graph An instance of the {@code Graph} class.
+   * @param nodeMapping A mapping from variables to nodes.
    * @return An instance of the {@code GraphUpdate} class.
    */
-  GraphUpdate process(ClauseUpdate[] clauseUpdates, Graph graph);
+  GraphUpdate process(ClauseUpdate[] clauseUpdates, Graph graph, IntUnaryOperator nodeMapping);
 
   /**
    * This method serializes the internal state of the processor.<br>

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseUpdateProcessor.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/ClauseUpdateProcessor.java
@@ -20,7 +20,7 @@ public interface ClauseUpdateProcessor {
    *
    * @param clauseUpdates An array of {@code ClauseUpdate}s.
    * @param graph An instance of the {@code Graph} class.
-   * @param nodeMapping A mapping from variables to nodes.
+   * @param nodeMapping A mapping from literals to nodes in the {@code graph}.
    * @return An instance of the {@code GraphUpdate} class.
    */
   GraphUpdate process(ClauseUpdate[] clauseUpdates, Graph graph, IntUnaryOperator nodeMapping);

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/CliqueInteractionGraph.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/CliqueInteractionGraph.java
@@ -2,6 +2,7 @@ package edu.kit.satviz.consumer.processing;
 
 import edu.kit.satviz.consumer.config.WeightFactor;
 import edu.kit.satviz.consumer.graph.WeightUpdate;
+import java.util.function.IntUnaryOperator;
 
 public class CliqueInteractionGraph extends VariableInteractionGraph {
 
@@ -15,10 +16,14 @@ public class CliqueInteractionGraph extends VariableInteractionGraph {
   }
 
   @Override
-  protected void process(WeightUpdate weightUpdate, int[] variables, float weight) {
+  protected void process(
+      WeightUpdate weightUpdate, int[] variables, float weight, IntUnaryOperator nodeMapping
+  ) {
     for (int i = 0; i < variables.length; i++) {
       for (int j = i + 1; j < variables.length; j++) {
-        weightUpdate.add(variables[i] - 1, variables[j] - 1, weight);
+        weightUpdate.add(
+            nodeMapping.applyAsInt(variables[i]), nodeMapping.applyAsInt(variables[j]), weight
+        );
       }
     }
   }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RecencyHeatmap.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RecencyHeatmap.java
@@ -4,10 +4,9 @@ import edu.kit.satviz.consumer.graph.Graph;
 import edu.kit.satviz.consumer.graph.HeatUpdate;
 import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.function.IntUnaryOperator;
 
 /**
  * A specialisation of {@link Heatmap}.
@@ -29,7 +28,7 @@ public class RecencyHeatmap extends Heatmap {
   }
 
   @Override
-  public HeatUpdate process(ClauseUpdate[] updates, Graph graph) {
+  public HeatUpdate process(ClauseUpdate[] updates, Graph graph, IntUnaryOperator nodeMapping) {
 
     for (ClauseUpdate update : updates) {
       Clause previous = recentClauses[cursor];
@@ -42,22 +41,22 @@ public class RecencyHeatmap extends Heatmap {
 
     int size = recentClauses.length;
     HeatUpdate update = new HeatUpdate();
-    zeroPendingVariables(update);
+    zeroPendingVariables(update, nodeMapping);
     for (int i = 0; i < size; i++) {
       Clause subject = recentClauses[(i + cursor) % size];
       if (subject == null) {
         continue;
       }
       for (int literal : subject.literals()) {
-        update.add(Math.abs(literal) - 1, (float) i / size);
+        update.add(nodeMapping.applyAsInt(literal), (float) i / size);
       }
     }
     return update;
   }
 
-  private void zeroPendingVariables(HeatUpdate update) {
+  private void zeroPendingVariables(HeatUpdate update, IntUnaryOperator nodeMapping) {
     for (int variable : setToZero) {
-      update.add(variable - 1, 0);
+      update.add(nodeMapping.applyAsInt(variable), 0);
     }
     setToZero.clear();
   }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RingInteractionGraph.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/RingInteractionGraph.java
@@ -3,6 +3,7 @@ package edu.kit.satviz.consumer.processing;
 import edu.kit.satviz.consumer.config.WeightFactor;
 import edu.kit.satviz.consumer.graph.WeightUpdate;
 import java.util.Arrays;
+import java.util.function.IntUnaryOperator;
 
 public class RingInteractionGraph extends VariableInteractionGraph {
 
@@ -16,11 +17,19 @@ public class RingInteractionGraph extends VariableInteractionGraph {
   }
 
   @Override
-  protected void process(WeightUpdate weightUpdate, int[] variables, float weight) {
+  protected void process(
+      WeightUpdate weightUpdate, int[] variables, float weight, IntUnaryOperator nodeMapping
+  ) {
     Arrays.sort(variables);
     for (int i = 0; i < variables.length - 1; i++) {
-      weightUpdate.add(variables[i] - 1, variables[i + 1] - 1, weight);
+      weightUpdate.add(
+          nodeMapping.applyAsInt(variables[i]), nodeMapping.applyAsInt(variables[i + 1]), weight
+      );
     }
-    weightUpdate.add(variables[0] - 1, variables[variables.length - 1] - 1, weight);
+    weightUpdate.add(
+        nodeMapping.applyAsInt(variables[0]),
+        nodeMapping.applyAsInt(variables[variables.length - 1]),
+        weight
+    );
   }
 }

--- a/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/VariableInteractionGraph.java
+++ b/satviz-consumer/src/main/java/edu/kit/satviz/consumer/processing/VariableInteractionGraph.java
@@ -9,7 +9,7 @@ import edu.kit.satviz.serial.StringSerializer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
+import java.util.function.IntUnaryOperator;
 
 /**
  * An implementation of {@code ClauseUpdateProcessor} that realises weight-changes for a
@@ -53,7 +53,9 @@ public abstract class VariableInteractionGraph implements ClauseUpdateProcessor 
   }
 
   @Override
-  public WeightUpdate process(ClauseUpdate[] clauseUpdates, Graph graph) {
+  public WeightUpdate process(
+      ClauseUpdate[] clauseUpdates, Graph graph, IntUnaryOperator nodeMapping
+  ) {
     WeightUpdate weightUpdate = new WeightUpdate();
     for (ClauseUpdate clauseUpdate : clauseUpdates) {
       int[] literals = clauseUpdate.clause().literals();
@@ -66,12 +68,14 @@ public abstract class VariableInteractionGraph implements ClauseUpdateProcessor 
 
       float weight = (float) weightFactor.apply(literals.length);
       weight = (clauseUpdate.type() == ClauseUpdate.Type.ADD) ? weight : -weight;
-      process(weightUpdate, literals, weight);
+      process(weightUpdate, literals, weight, nodeMapping);
     }
     return weightUpdate;
   }
 
-  protected abstract void process(WeightUpdate weightUpdate, int[] variables, float weight);
+  protected abstract void process(
+      WeightUpdate weightUpdate, int[] variables, float weight, IntUnaryOperator nodeMapping
+  );
 
   @Override
   public void serialize(OutputStream out) {

--- a/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/ClauseCoordinatorTest.java
+++ b/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/ClauseCoordinatorTest.java
@@ -79,7 +79,7 @@ class ClauseCoordinatorTest {
       processor1AdvanceCalls++;
     }
     verify(processor1, times(processor1AdvanceCalls)).process(
-        notNull(), eq(graph), DEFAULT_NODE_MAPPING
+        notNull(), eq(graph), eq(DEFAULT_NODE_MAPPING)
     );
     coordinator.addProcessor(processor2);
     while (clausesAdded < clauseUpdates.length) {
@@ -88,10 +88,10 @@ class ClauseCoordinatorTest {
       processor2AdvanceCalls++;
     }
     verify(processor1, times(processor1AdvanceCalls)).process(
-            notNull(), eq(graph), DEFAULT_NODE_MAPPING
+            notNull(), eq(graph), eq(DEFAULT_NODE_MAPPING)
     );
     verify(processor2, times(processor2AdvanceCalls)).process(
-        notNull(), eq(graph), DEFAULT_NODE_MAPPING
+        notNull(), eq(graph), eq(DEFAULT_NODE_MAPPING)
     );
   }
 
@@ -115,10 +115,10 @@ class ClauseCoordinatorTest {
       coordinator.addClauseUpdate(update);
     }
     assertEquals(4, coordinator.totalUpdateCount());
-    verify(processor1, never()).process(notNull(), eq(graph), DEFAULT_NODE_MAPPING);
+    verify(processor1, never()).process(notNull(), eq(graph), eq(DEFAULT_NODE_MAPPING));
     coordinator.advanceVisualization(1);
     verify(processor1).process(
-        eq(Arrays.copyOfRange(clauseUpdates, 0, 1)), eq(graph), DEFAULT_NODE_MAPPING
+        Arrays.copyOfRange(clauseUpdates, 0, 1), graph, DEFAULT_NODE_MAPPING
     );
   }
 
@@ -193,7 +193,7 @@ class ClauseCoordinatorTest {
     }
     assertEquals(0, coordinator.currentUpdate());
     coordinator.seekToUpdate(4);
-    verify(processor1).process(eq(someUpdates), eq(graph), DEFAULT_NODE_MAPPING);
+    verify(processor1).process(someUpdates, graph, DEFAULT_NODE_MAPPING);
     assertEquals(4, coordinator.currentUpdate());
     // unnecessary deserialization should be avoided
     verify(graph, never()).deserialize(any());
@@ -252,8 +252,8 @@ class ClauseCoordinatorTest {
     coordinator.takeSnapshot(); // first serialization of processor2
     // -  -  -  p  =  =  =  = >pp ~  ~
 
-    verify(processor1, times(2)).process(any(), any(), DEFAULT_NODE_MAPPING);
-    verify(processor2, times(1)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor1, times(2)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
+    verify(processor2, times(1)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
 
     // -  -  -  p  =  =  =  = >pp ~  ~
     coordinator.seekToUpdate(5);
@@ -264,8 +264,8 @@ class ClauseCoordinatorTest {
     verify(processor1, times(0)).reset();
     verify(processor2, times(0)).deserialize(any());
     verify(processor2, times(1)).reset();
-    verify(processor1, times(3)).process(any(), any(), DEFAULT_NODE_MAPPING);
-    verify(processor2, times(2)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor1, times(3)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
+    verify(processor2, times(2)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
 
     // -  -  -  p >c  =  =  =  pp ~  ~
     coordinator.takeSnapshot(); // serializing reset state of processor2 (not necessary)
@@ -281,8 +281,8 @@ class ClauseCoordinatorTest {
     verify(processor1, times(1)).reset();
     verify(processor2, times(0)).deserialize(any());
     verify(processor2, times(2)).reset();
-    verify(processor1, times(4)).process(any(), any(), DEFAULT_NODE_MAPPING);
-    verify(processor2, times(3)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor1, times(4)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
+    verify(processor2, times(3)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
 
     // = >c  -  p  pp =  =  =  pp ~  ~
     coordinator.seekToUpdate(7);
@@ -294,8 +294,8 @@ class ClauseCoordinatorTest {
     verify(processor1, times(1)).reset();
     verify(processor2, times(1)).deserialize(any());
     verify(processor2, times(2)).reset();
-    verify(processor1, times(5)).process(any(), any(), DEFAULT_NODE_MAPPING);
-    verify(processor2, times(4)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor1, times(5)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
+    verify(processor2, times(4)).process(any(), any(), eq(DEFAULT_NODE_MAPPING));
   }
 
   @Test

--- a/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/ClauseCoordinatorTest.java
+++ b/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/ClauseCoordinatorTest.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntUnaryOperator;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.verify;
 class ClauseCoordinatorTest {
 
   private static final String TEMP_DIR = "src/test/temp";
+  private static final IntUnaryOperator DEFAULT_NODE_MAPPING = literal -> Math.abs(literal) - 1;
 
   private int clausesAdded;
   private int currentlyAdvanced;
@@ -61,7 +64,7 @@ class ClauseCoordinatorTest {
     changeListenerCallAmount = new AtomicInteger();
 
     Path tempDir = Files.createDirectory(Paths.get(TEMP_DIR));
-    coordinator = new ClauseCoordinator(graph, tempDir, 6);
+    coordinator = new ClauseCoordinator(graph, tempDir, 6, DEFAULT_NODE_MAPPING);
     coordinator.addProcessor(processor1);
 
     coordinator.registerChangeListener(changeListenerCallAmount::getAndIncrement);
@@ -75,15 +78,21 @@ class ClauseCoordinatorTest {
       addUpdatesAndAdvance(Arrays.copyOfRange(clauseUpdates, i - 4, i));
       processor1AdvanceCalls++;
     }
-    verify(processor1, times(processor1AdvanceCalls)).process(notNull(), eq(graph));
+    verify(processor1, times(processor1AdvanceCalls)).process(
+        notNull(), eq(graph), DEFAULT_NODE_MAPPING
+    );
     coordinator.addProcessor(processor2);
     while (clausesAdded < clauseUpdates.length) {
       addUpdatesAndAdvance(Arrays.copyOfRange(clauseUpdates, clausesAdded, clausesAdded + 1));
       processor1AdvanceCalls++;
       processor2AdvanceCalls++;
     }
-    verify(processor1, times(processor1AdvanceCalls)).process(notNull(), eq(graph));
-    verify(processor2, times(processor2AdvanceCalls)).process(notNull(), eq(graph));
+    verify(processor1, times(processor1AdvanceCalls)).process(
+            notNull(), eq(graph), DEFAULT_NODE_MAPPING
+    );
+    verify(processor2, times(processor2AdvanceCalls)).process(
+        notNull(), eq(graph), DEFAULT_NODE_MAPPING
+    );
   }
 
   private void addUpdatesAndAdvance(ClauseUpdate[] clauseUpdatesToAdd)
@@ -106,9 +115,11 @@ class ClauseCoordinatorTest {
       coordinator.addClauseUpdate(update);
     }
     assertEquals(4, coordinator.totalUpdateCount());
-    verify(processor1, never()).process(notNull(), eq(graph));
+    verify(processor1, never()).process(notNull(), eq(graph), DEFAULT_NODE_MAPPING);
     coordinator.advanceVisualization(1);
-    verify(processor1).process(eq(Arrays.copyOfRange(clauseUpdates, 0, 1)), eq(graph));
+    verify(processor1).process(
+        eq(Arrays.copyOfRange(clauseUpdates, 0, 1)), eq(graph), DEFAULT_NODE_MAPPING
+    );
   }
 
   // registerChangeListener
@@ -182,7 +193,7 @@ class ClauseCoordinatorTest {
     }
     assertEquals(0, coordinator.currentUpdate());
     coordinator.seekToUpdate(4);
-    verify(processor1).process(eq(someUpdates), eq(graph));
+    verify(processor1).process(eq(someUpdates), eq(graph), DEFAULT_NODE_MAPPING);
     assertEquals(4, coordinator.currentUpdate());
     // unnecessary deserialization should be avoided
     verify(graph, never()).deserialize(any());
@@ -241,8 +252,8 @@ class ClauseCoordinatorTest {
     coordinator.takeSnapshot(); // first serialization of processor2
     // -  -  -  p  =  =  =  = >pp ~  ~
 
-    verify(processor1, times(2)).process(any(), any());
-    verify(processor2, times(1)).process(any(), any());
+    verify(processor1, times(2)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor2, times(1)).process(any(), any(), DEFAULT_NODE_MAPPING);
 
     // -  -  -  p  =  =  =  = >pp ~  ~
     coordinator.seekToUpdate(5);
@@ -253,8 +264,8 @@ class ClauseCoordinatorTest {
     verify(processor1, times(0)).reset();
     verify(processor2, times(0)).deserialize(any());
     verify(processor2, times(1)).reset();
-    verify(processor1, times(3)).process(any(), any());
-    verify(processor2, times(2)).process(any(), any());
+    verify(processor1, times(3)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor2, times(2)).process(any(), any(), DEFAULT_NODE_MAPPING);
 
     // -  -  -  p >c  =  =  =  pp ~  ~
     coordinator.takeSnapshot(); // serializing reset state of processor2 (not necessary)
@@ -270,8 +281,8 @@ class ClauseCoordinatorTest {
     verify(processor1, times(1)).reset();
     verify(processor2, times(0)).deserialize(any());
     verify(processor2, times(2)).reset();
-    verify(processor1, times(4)).process(any(), any());
-    verify(processor2, times(3)).process(any(), any());
+    verify(processor1, times(4)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor2, times(3)).process(any(), any(), DEFAULT_NODE_MAPPING);
 
     // = >c  -  p  pp =  =  =  pp ~  ~
     coordinator.seekToUpdate(7);
@@ -283,8 +294,8 @@ class ClauseCoordinatorTest {
     verify(processor1, times(1)).reset();
     verify(processor2, times(1)).deserialize(any());
     verify(processor2, times(2)).reset();
-    verify(processor1, times(5)).process(any(), any());
-    verify(processor2, times(4)).process(any(), any());
+    verify(processor1, times(5)).process(any(), any(), DEFAULT_NODE_MAPPING);
+    verify(processor2, times(4)).process(any(), any(), DEFAULT_NODE_MAPPING);
   }
 
   @Test

--- a/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/CliqueInteractionGraphTest.java
+++ b/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/CliqueInteractionGraphTest.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.IntUnaryOperator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class CliqueInteractionGraphTest {
 
   private static final WeightFactor INITIAL_FACTOR = WeightFactor.CONSTANT;
+  private static final IntUnaryOperator DEFAULT_NODE_MAPPING = literal -> Math.abs(literal) - 1;
 
   /**
    * Clauses, that could be interpreted as an entire DRAT proof:
@@ -79,7 +81,9 @@ class CliqueInteractionGraphTest {
   void test_process_eachWeightFactor() {
     for (WeightFactor factor : WeightFactor.values()) {
       vig.setWeightFactor(factor);
-      assertEquals(WEIGHT_UPDATES.get(factor), vig.process(clauseUpdates, null));
+      assertEquals(WEIGHT_UPDATES.get(factor), vig.process(
+          clauseUpdates, null, DEFAULT_NODE_MAPPING)
+      );
     }
   }
 

--- a/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/FrequencyHeatmapTest.java
+++ b/satviz-consumer/src/test/java/edu/kit/satviz/consumer/processing/FrequencyHeatmapTest.java
@@ -6,6 +6,8 @@ import edu.kit.satviz.consumer.graph.HeatUpdate;
 import edu.kit.satviz.sat.Clause;
 import edu.kit.satviz.sat.ClauseUpdate;
 import java.util.Arrays;
+import java.util.function.IntUnaryOperator;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +25,8 @@ class FrequencyHeatmapTest {
       .map(c -> new ClauseUpdate(c, ClauseUpdate.Type.ADD))
       .toArray(ClauseUpdate[]::new);
 
+  private static final IntUnaryOperator DEFAULT_NODE_MAPPING = literal -> Math.abs(literal) - 1;
+
   private Heatmap heatmap;
 
   @BeforeEach
@@ -32,7 +36,9 @@ class FrequencyHeatmapTest {
 
   @Test
   void test_process_single() {
-    var result = heatmap.process(new ClauseUpdate[] {UPDATES[0]}, null);
+    var result = heatmap.process(
+        new ClauseUpdate[] {UPDATES[0]}, null, DEFAULT_NODE_MAPPING
+    );
     var expected = new HeatUpdate();
     expected.add(0, 1);
     expected.add(5, 1);
@@ -44,7 +50,9 @@ class FrequencyHeatmapTest {
   @Test
   void test_process_multiple_overFull() {
     test_process_multiple_notFull();
-    var result = heatmap.process(Arrays.copyOfRange(UPDATES, 2, 5), null);
+    var result = heatmap.process(
+        Arrays.copyOfRange(UPDATES, 2, 5), null, DEFAULT_NODE_MAPPING
+    );
     var expected = new HeatUpdate();
     expected.add(0, 2f / 3); // 1: 2
     expected.add(1, 2f / 3); // 2: 2
@@ -58,7 +66,9 @@ class FrequencyHeatmapTest {
 
   @Test
   void test_process_multiple_notFull() {
-    var result = heatmap.process(Arrays.copyOfRange(UPDATES, 0, 2), null);
+    var result = heatmap.process(
+        Arrays.copyOfRange(UPDATES, 0, 2), null, DEFAULT_NODE_MAPPING
+    );
     var expected = new HeatUpdate();
     expected.add(0, 1f / 2);
     expected.add(1, 1f / 2);
@@ -71,7 +81,9 @@ class FrequencyHeatmapTest {
 
   @Test
   void test_process_multiple_full() {
-    var result = heatmap.process(Arrays.copyOfRange(UPDATES, 0, 3), null);
+    var result = heatmap.process(
+        Arrays.copyOfRange(UPDATES, 0, 3), null, DEFAULT_NODE_MAPPING
+    );
     var expected = new HeatUpdate();
     expected.add(0, 2f / 3); // 0: 2,
     expected.add(1, 2f / 3); // 1: 2,
@@ -84,7 +96,7 @@ class FrequencyHeatmapTest {
 
   @Test
   void test_reset() {
-    heatmap.process(UPDATES, null);
+    heatmap.process(UPDATES, null, DEFAULT_NODE_MAPPING);
     heatmap.reset();
     test_process_single();
   }


### PR DESCRIPTION
Fügt einen zusätzlichen Parameter in `ClauseUpdateProcessor` hinzu, der eine Funktion `(int) -> int` beschreibt. Diese Funktion übersetzt Literale bzw. Variablen aus Klauseln in Knotenindizes eines Graphen. Dies kann später genutzt werden, um Kontraktion zu implementieren.